### PR TITLE
fix(homebrew): symlink CLI binaries into Homebrew bin

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -62,6 +62,8 @@ jobs:
 
             def install
               system "npm", "install", *std_npm_args
+              bin.install_symlink libexec/"bin/youtube-music-cli"
+              bin.install_symlink libexec/"bin/ymc"
             end
 
             test do

--- a/Formula/youtube-music-cli.rb
+++ b/Formula/youtube-music-cli.rb
@@ -9,6 +9,8 @@ class YoutubeMusicCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
+    bin.install_symlink libexec/"bin/youtube-music-cli"
+    bin.install_symlink libexec/"bin/ymc"
   end
 
   test do

--- a/tests/homebrew-formula.test.js
+++ b/tests/homebrew-formula.test.js
@@ -1,0 +1,39 @@
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import test from 'ava';
+
+const repoRoot = process.cwd();
+const formulaPath = join(repoRoot, 'Formula', 'youtube-music-cli.rb');
+const workflowPath = join(
+	repoRoot,
+	'.github',
+	'workflows',
+	'homebrew-publish.yml',
+);
+
+const expectedSymlinks = [
+	'bin.install_symlink libexec/"bin/youtube-music-cli"',
+	'bin.install_symlink libexec/"bin/ymc"',
+];
+
+test('homebrew formula links both CLI entrypoints into bin', t => {
+	const formula = readFileSync(formulaPath, 'utf8');
+
+	for (const expectedLine of expectedSymlinks) {
+		t.true(
+			formula.includes(expectedLine),
+			`Expected formula to include: ${expectedLine}`,
+		);
+	}
+});
+
+test('homebrew publish workflow generates the same bin symlinks', t => {
+	const workflow = readFileSync(workflowPath, 'utf8');
+
+	for (const expectedLine of expectedSymlinks) {
+		t.true(
+			workflow.includes(expectedLine),
+			`Expected workflow to include: ${expectedLine}`,
+		);
+	}
+});


### PR DESCRIPTION
# Summary
- add explicit Homebrew `bin` symlinks for `youtube-music-cli` and `ymc`
- update the Homebrew publish workflow so future releases keep the fix
- add a regression test that fails when either file stops generating the symlinks

# Why
`brew install youtube-music-cli` installs the package into `libexec/bin`, but the formula never linked those entrypoints into Homebrew's standard `bin` directory. As a result, users can install successfully and still get `command not found` for `youtube-music-cli`.

# How to validate
1. Run `TMPDIR=/private/tmp bunx ava tests/homebrew-formula.test.js`
2. Confirm both tests pass.
3. Inspect `Formula/youtube-music-cli.rb` and verify it links both `youtube-music-cli` and `ymc` from `libexec/bin` into `bin`.
4. Inspect `.github/workflows/homebrew-publish.yml` and verify the generated formula includes the same symlink lines.

# Screenshots / GIF
N/A

# Risk / rollout notes
Low risk. The change only exposes the package's existing npm bin entries through Homebrew's standard `bin` directory and keeps the release automation in sync.

## Summary by Sourcery

Ensure the Homebrew formula and publish workflow expose the CLI binaries via Homebrew’s standard bin directory and guard this behavior with tests.

Bug Fixes:
- Link the youtube-music-cli and ymc executables from libexec/bin into Homebrew’s bin directory so installed users can invoke the CLI commands.

Tests:
- Add regression tests verifying both the Homebrew formula and publish workflow include the expected bin symlink lines for the CLI entrypoints.