### PR TITLE
fix: escape key navigates back from search, lyrics, favorites, and plugin manager

### DIFF
--- a/source/components/favorites/FavoritesList.tsx
+++ b/source/components/favorites/FavoritesList.tsx
@@ -4,6 +4,7 @@ import {useTheme} from '../../hooks/useTheme.ts';
 import {useFavorites} from '../../stores/favorites.store.tsx';
 import {usePlayer} from '../../hooks/usePlayer.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useNavigation} from '../../hooks/useNavigation.ts';
 import {ICONS} from '../../utils/icons.ts';
 import {truncate} from '../../utils/format.ts';
 import {useTerminalSize} from '../../hooks/useTerminalSize.ts';
@@ -15,6 +16,7 @@ export default function FavoritesList() {
 	const {play, dispatch: playerDispatch} = usePlayer();
 	const {columns, rows} = useTerminalSize();
 	const [selectedIndex, setSelectedIndex] = useState(0);
+	const {dispatch} = useNavigation();
 
 	// Navigation
 	const navigateUp = useCallback(() => {
@@ -57,6 +59,10 @@ export default function FavoritesList() {
 		}
 	}, [favorites, selectedIndex, removeFavorite]);
 
+	const goBack = useCallback(() => {
+		dispatch({category: 'GO_BACK'});
+	}, [dispatch]);
+
 	// Key bindings
 	useKeyBinding(KEYBINDINGS.UP, navigateUp);
 	useKeyBinding(KEYBINDINGS.DOWN, navigateDown);
@@ -67,6 +73,7 @@ export default function FavoritesList() {
 	// Let's add specific shortcuts for playing all/shuffle
 	useKeyBinding(['p'], playAll);
 	useKeyBinding(['s'], shufflePlayAll);
+	useKeyBinding(['escape'], goBack, {bypassBlock: true});
 
 	if (favorites.length === 0) {
 		return (

--- a/source/components/layouts/LyricsLayout.tsx
+++ b/source/components/layouts/LyricsLayout.tsx
@@ -1,8 +1,10 @@
 // Lyrics view layout - displays synced or plain lyrics
-import {useState, useEffect} from 'react';
+import {useState, useEffect, useCallback} from 'react';
 import {Box, Text} from 'ink';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {usePlayer} from '../../hooks/usePlayer.ts';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useNavigation} from '../../hooks/useNavigation.ts';
 import {
 	getLyricsService,
 	type LyricLine,
@@ -22,6 +24,13 @@ export default function LyricsLayout() {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const lyricsService = getLyricsService();
+	const {dispatch} = useNavigation();
+
+	const goBack = useCallback(() => {
+		dispatch({category: 'GO_BACK'});
+	}, [dispatch]);
+
+	useKeyBinding(['escape'], goBack, {bypassBlock: true});
 
 	// Fetch lyrics when track changes
 	useEffect(() => {

--- a/source/components/layouts/PluginsLayout.tsx
+++ b/source/components/layouts/PluginsLayout.tsx
@@ -4,6 +4,7 @@ import {Box, Text} from 'ink';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {usePlugins} from '../../stores/plugins.store.tsx';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useNavigation} from '../../hooks/useNavigation.ts';
 import {KEYBINDINGS} from '../../utils/constants.ts';
 import PluginsList from '../plugins/PluginsList.tsx';
 import PluginInstallDialog from '../plugins/PluginInstallDialog.tsx';
@@ -21,6 +22,7 @@ export default function PluginsLayout() {
 		updatePlugin,
 	} = usePlugins();
 	const [viewMode, setViewMode] = useState<ViewMode>('list');
+	const {dispatch: navDispatch} = useNavigation();
 
 	const {installedPlugins, selectedIndex, isLoading, error, lastAction} = state;
 
@@ -77,6 +79,14 @@ export default function PluginsLayout() {
 		setViewMode('list');
 	}, []);
 
+	const handleEscape = useCallback(() => {
+		if (viewMode === 'install') {
+			closeInstall();
+		} else {
+			navDispatch({category: 'GO_BACK'});
+		}
+	}, [viewMode, closeInstall, navDispatch]);
+
 	// Key bindings
 	useKeyBinding(KEYBINDINGS.UP, navigateUp);
 	useKeyBinding(KEYBINDINGS.DOWN, navigateDown);
@@ -84,6 +94,7 @@ export default function PluginsLayout() {
 	useKeyBinding(['r'], removePlugin);
 	useKeyBinding(['u'], handleUpdate);
 	useKeyBinding(['i'], openInstall);
+	useKeyBinding(['escape'], handleEscape, {bypassBlock: true});
 
 	// Show install dialog
 	if (viewMode === 'install') {

--- a/source/components/search/SearchBar.tsx
+++ b/source/components/search/SearchBar.tsx
@@ -49,13 +49,15 @@ function SearchBar({onInput, isActive = true}: Props) {
 		[dispatch, onInput, isActive, config],
 	);
 
-	// Handle clearing search
+	// Clear search text, or navigate back if already empty
 	const clearSearch = useCallback(() => {
-		if (isActive) {
+		if (isActive && input !== '') {
 			setInput('');
 			onInput('');
+		} else {
+			dispatch({category: 'GO_BACK'});
 		}
-	}, [isActive, onInput]);
+	}, [isActive, onInput, input, dispatch]);
 
 	useKeyBinding(['tab'], cycleType);
 	useKeyBinding(['escape'], clearSearch, {bypassBlock: true});


### PR DESCRIPTION
## What's the issue?

Pressing `Escape` in several views either did nothing or only partially worked:

- **Search** — clears the input when it has text, but pressing `Escape` again (empty input) or pressing it while browsing results did nothing.
- **Lyrics** — the UI hint said "Press Esc to go back" but the key was never bound.
- **Favorites** — same: no `Escape` binding at all.
- **Plugin Manager** — same: showed `Esc=Back` in the shortcuts bar but never wired it up.

## What's the fix?

### `SearchBar.tsx` (original fix)
The `clearSearch` callback now checks whether the input is empty before deciding what to do:

- **Input has text** → clears it (same as before)
- **Input is empty, or the bar is inactive** (browsing results) → dispatches `GO_BACK`

```ts
// Before
const clearSearch = useCallback(() => {
    if (isActive) {
        setInput('');
        onInput('');
    }
}, [isActive, onInput]);

// After
const clearSearch = useCallback(() => {
    if (isActive && input !== '') {
        setInput('');
        onInput('');
    } else {
        dispatch({category: 'GO_BACK'});
    }
}, [isActive, onInput, input, dispatch]);
```

### `LyricsLayout.tsx`, `FavoritesList.tsx`, `PluginsLayout.tsx` (expanded fix)
Each view now imports `useNavigation` and registers an escape binding with `bypassBlock: true` so it always fires:

```ts
useKeyBinding(['escape'], goBack, {bypassBlock: true});
```

For **Plugin Manager** specifically, `Escape` first closes the install dialog if it's open, and only dispatches `GO_BACK` if already on the list view.

The root cause across all views is the same: `SearchBar` registers its escape binding with `bypassBlock: true`, intercepting the key before the global handler can fire. Views without their own escape binding were simply left without any back navigation on keyboard.

## Files changed

| File | Change |
|------|--------|
| `source/components/search/SearchBar.tsx` | `GO_BACK` fallback when input is empty |
| `source/components/layouts/LyricsLayout.tsx` | Add escape → `GO_BACK` binding |
| `source/components/favorites/FavoritesList.tsx` | Add escape → `GO_BACK` binding |
| `source/components/layouts/PluginsLayout.tsx` | Add escape → `GO_BACK` (or close install dialog) binding |

## Summary by Sourcery

Bug Fixes:
- Allow Escape to navigate back from search, lyrics, favorites, and plugin manager views instead of doing nothing.