### PR TITLE
fix: song restarts from beginning after pause/resume

### DIFF
--- a/source/services/player/player.service.ts
+++ b/source/services/player/player.service.ts
@@ -13,6 +13,7 @@ export type PlayOptions = {
 	equalizerPreset?: EqualizerPreset;
 	volumeFadeDuration?: number;
 	duration?: number;
+	startPosition?: number;
 };
 
 export type MpvArgsOptions = PlayOptions & {
@@ -72,6 +73,10 @@ export function buildMpvArgs(
 
 	if (options.proxy) {
 		mpvArgs.push(`--http-proxy=${options.proxy}`);
+	}
+
+	if (options.startPosition && options.startPosition > 0) {
+		mpvArgs.push(`--start=${Math.floor(options.startPosition)}`);
 	}
 
 	mpvArgs.push(url);
@@ -332,11 +337,11 @@ class PlayerService {
 		const videoIdMatch = url.match(/[?&]v=([^&]+)/);
 		const videoId = videoIdMatch ? videoIdMatch[1] : null;
 
-		// Guard: Don't spawn if same track already playing
-		if (this.currentTrackId === videoId && this.mpvProcess && this.isPlaying) {
+		// Guard: Don't spawn if same track already loaded
+		if (this.currentTrackId === videoId && this.mpvProcess) {
 			logger.info(
 				'PlayerService',
-				'Same track already playing, skipping spawn',
+				'Same track already loaded, skipping spawn',
 				{
 					videoId,
 				},
@@ -381,6 +386,7 @@ class PlayerService {
 					gaplessPlayback: options?.gaplessPlayback,
 					crossfadeDuration: options?.crossfadeDuration,
 					equalizerPreset: options?.equalizerPreset,
+					startPosition: options?.startPosition,
 				});
 
 				// Capture process in local var so stale exit handlers from a killed
@@ -514,8 +520,8 @@ class PlayerService {
 
 	resume(): void {
 		logger.debug('PlayerService', 'resume() called');
-		this.isPlaying = true;
 		if (this.ipcSocket && !this.ipcSocket.destroyed) {
+			this.isPlaying = true;
 			this.sendIpcCommand(['set_property', 'pause', false]);
 			// Reapply volume after resume to ensure audio isn't muted
 			if (this.currentVolume !== undefined) {
@@ -523,7 +529,7 @@ class PlayerService {
 					this.sendIpcCommand(['set_property', 'volume', this.currentVolume]);
 				}, 100);
 			}
-		} else if (!this.isPlaying && !this.mpvProcess && this.currentUrl) {
+		} else if (!this.mpvProcess && this.currentUrl) {
 			void this.play(this.currentUrl, {volume: this.currentVolume});
 		}
 	}

--- a/source/stores/player.store.tsx
+++ b/source/stores/player.store.tsx
@@ -280,6 +280,7 @@ export function playerReducer(
 				repeat: action.repeat,
 				autoplay: action.autoplay ?? true,
 				isPlaying: false, // Don't auto-play restored state
+				progress: action.progress ?? 0,
 				abLoop: {a: null, b: null},
 			};
 
@@ -530,6 +531,7 @@ function PlayerManager() {
 						equalizerPreset: config.get('equalizerPreset') ?? 'flat',
 						volumeFadeDuration: config.get('volumeFadeDuration') ?? 0,
 						duration: track.duration,
+						startPosition: state.progress > 0 ? state.progress : undefined,
 					});
 
 					logger.info('PlayerManager', 'Playback started successfully', {


### PR DESCRIPTION
## Problem

When pausing a song and pressing play again, the song would restart from the beginning with a few seconds of silence before audio started. The silence is mpv buffering a new process — confirming a fresh spawn was happening instead of a simple resume.

Three bugs were working together to cause this:

---

### Bug 1 — `play()` guard checked `&& this.isPlaying`

```ts
// Before — guard fails when paused (isPlaying = false):
if (this.currentTrackId === videoId && this.mpvProcess && this.isPlaying) {
```

When mpv was paused, `isPlaying` was `false`, so the guard never fired and a new mpv process was spawned for the same track.

**Fix:** Remove `&& this.isPlaying` — if the process exists and the track ID matches, skip the spawn.

---

### Bug 2 — `resume()` fallback was dead code

```ts
// Before — isPlaying set to true BEFORE the else-if that checks !isPlaying:
resume(): void {
    this.isPlaying = true;               // ← always true after this line
    if (this.ipcSocket && ...) { ... }
    else if (!this.isPlaying && ...) {   // ← can never be true
        void this.play(...);             // ← dead code
    }
}
```

The `else if` fallback (re-spawn when mpv has died) could never trigger because `isPlaying` was unconditionally set to `true` on the first line.

**Fix:** Move `this.isPlaying = true` inside the `if` branch where the IPC socket is alive.

---

### Bug 3 — `RESTORE_STATE` dropped saved `progress`

```ts
// Before — progress field silently ignored:
case 'RESTORE_STATE':
    return {
        ...state,
        currentTrack: action.currentTrack,
        // progress: action.progress  ← missing!
        ...
    };
```

On app restart, `state.progress` was always reset to `0`, so pressing play after a restart always started the track from the beginning regardless of where you left off.

**Fix:**
1. Restore `progress: action.progress ?? 0` in the `RESTORE_STATE` reducer.
2. Pass `startPosition: state.progress` to `playerService.play()` so mpv starts at the restored position via `--start=N`.
3. Add `startPosition?: number` to `PlayOptions` / `buildMpvArgs`.

---

## Testing

- Play a song → pause at e.g. 1:30 → press play → audio resumes immediately from 1:30 (no restart, no silence gap).
- Close and reopen the app while a song is paused → press play → song resumes from the saved position.

## Summary by Sourcery

Fix pausing and resuming playback so tracks reliably continue from the correct position instead of restarting.

Bug Fixes:
- Prevent spawning a new mpv process when resuming an already loaded track.
- Allow the resume fallback to correctly restart playback when the mpv process has died.
- Restore and use saved playback progress after app restart so tracks resume from where they left off.

Enhancements:
- Add support for starting mpv playback from an arbitrary position via a new startPosition option passed through to mpv arguments.