### PR TITLE
fix: use IPC loadfile for URL loading instead of CLI arg

### DIFF
--- a/source/services/player/player.service.ts
+++ b/source/services/player/player.service.ts
@@ -187,9 +187,14 @@ class PlayerService {
 					// This ensures mpv is fully ready before we ask it to
 					// resolve a YouTube URL through yt-dlp.
 					if (urlToLoad) {
-						logger.info('PlayerService', 'Loading URL via IPC loadfile', {
-							url: urlToLoad.substring(0, 100),
-						});
+						try {
+							const parsed = new URL(urlToLoad);
+							logger.info('PlayerService', 'Loading URL via IPC loadfile', {
+								url: `${parsed.origin}${parsed.pathname}`,
+							});
+						} catch {
+							logger.info('PlayerService', 'Loading URL via IPC loadfile');
+						}
 						this.sendIpcCommand(['loadfile', urlToLoad]);
 					}
 
@@ -435,7 +440,8 @@ class PlayerService {
 							logger.warn('PlayerService', 'Failed to connect IPC', {
 								error: error.message,
 							});
-							// IPC failed - mpv is idle with no URL loaded
+							// IPC failed - mpv is idle with no URL loaded, clean it up
+							this.stop();
 							handleError(new Error(`IPC connection failed: ${error.message}`));
 						});
 				}, ipcDelay);

--- a/tests/player-service-mpv-args.test.js
+++ b/tests/player-service-mpv-args.test.js
@@ -4,13 +4,12 @@ import {pathToFileURL} from 'node:url';
 
 register('ts-node/esm', pathToFileURL('./'));
 
-const TEST_URL = 'https://www.youtube.com/watch?v=abc123';
 const IPC_PATH = '/tmp/mpv-test';
 
 test('player-service-mpv-args: buildMpvArgs respects the gapless playback toggle', async t => {
 	const {buildMpvArgs} =
 		await import('../source/services/player/player.service.ts');
-	const args = buildMpvArgs(TEST_URL, IPC_PATH, {
+	const args = buildMpvArgs(IPC_PATH, {
 		volume: 55,
 		gaplessPlayback: false,
 	});
@@ -22,7 +21,7 @@ test('player-service-mpv-args: buildMpvArgs respects the gapless playback toggle
 test('player-service-mpv-args: buildMpvArgs adds acrossfade and normalization filters when configured', async t => {
 	const {buildMpvArgs} =
 		await import('../source/services/player/player.service.ts');
-	const args = buildMpvArgs(TEST_URL, IPC_PATH, {
+	const args = buildMpvArgs(IPC_PATH, {
 		volume: 55,
 		crossfadeDuration: 4,
 		audioNormalization: true,


### PR DESCRIPTION
## Summary

- Separates URL loading from mpv spawn arguments to fix a race condition with `--idle=yes`
- URL is now sent via IPC `loadfile` command after the socket connects, instead of being passed as a CLI argument
- Properly errors when IPC connection fails (previously called `handleSuccess()` even on failure, leaving mpv idle with nothing to play)
- Cleans up `buildMpvArgs` signature since URL is no longer passed through it

## Problem

mpv is spawned with `--idle=yes` and the YouTube URL as a CLI argument. The IPC connection + property observation happens 200ms later. This creates a race condition where:

1. mpv starts resolving the URL via yt-dlp (takes seconds)
2. IPC connects and begins observing properties before resolution completes
3. In some cases, playback never starts — progress stays at 0:00

## Fix

Spawn mpv in pure idle mode (no URL), connect IPC, register observers, *then* send `loadfile` via IPC. This guarantees: socket ready → observers registered → URL loaded.

## Related

Closes #16 (partially — the reporter's specific case was VPN-related, but this addresses the underlying architectural issue)

## Test plan

- [ ] Launch TUI, search and play a track — audio should play with progress bar advancing
- [ ] Verify volume is correct (not 0) via `ps aux | grep mpv`
- [ ] Test with `--headless` mode
- [ ] Test track skipping (next/previous)
- [ ] Test on slow connections where yt-dlp resolution takes >1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Load media URLs into mpv via IPC instead of CLI arguments to avoid race conditions and fail playback cleanly when IPC cannot be established.

Bug Fixes:
- Resolve a race condition between mpv startup with --idle and IPC property observation by deferring URL loading until after the IPC socket is connected.
- Ensure playback reports an error when IPC connection fails instead of silently leaving mpv idle with nothing to play.

Enhancements:
- Simplify mpv argument construction by removing the URL parameter and documenting the IPC-based URL loading behavior.