### PR TITLE
fix: fixing restarting music when pausing it

### DIFF
--- a/source/services/player/player.service.ts
+++ b/source/services/player/player.service.ts
@@ -359,11 +359,10 @@ class PlayerService {
 			return;
 		}
 
-		this.currentTrackId = videoId || null;
-
 		// Stop any existing playback
 		this.stop();
 
+		this.currentTrackId = videoId || null;
 		this.currentUrl = url;
 		if (options?.volume !== undefined) {
 			this.currentVolume = options.volume;
@@ -530,17 +529,20 @@ class PlayerService {
 
 	resume(): void {
 		logger.debug('PlayerService', 'resume() called');
-		this.isPlaying = true;
-		if (this.ipcSocket && !this.ipcSocket.destroyed) {
+		if (!!this.ipcSocket && !this.ipcSocket.destroyed) {
 			this.sendIpcCommand(['set_property', 'pause', false]);
-			// Reapply volume after resume to ensure audio isn't muted
+			this.isPlaying = true;
 			if (this.currentVolume !== undefined) {
 				setTimeout(() => {
 					this.sendIpcCommand(['set_property', 'volume', this.currentVolume]);
 				}, 100);
 			}
-		} else if (!this.isPlaying && !this.mpvProcess && this.currentUrl) {
+			return;
+		}
+
+		if (!this.mpvProcess && this.currentUrl) {
 			void this.play(this.currentUrl, {volume: this.currentVolume});
+			return;
 		}
 	}
 


### PR DESCRIPTION
Description
Fix the issue where pressing the spacebar while music is playing would restart the track from the beginning instead of pausing and resuming from the current position.

## Summary by Sourcery

Bug Fixes:
- Prevent restarting the track when resuming playback by correctly resuming the existing mpv process or reusing the current track state.