### PR TITLE
fix(install): require bun in install.sh to match runtime dependency

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,12 +2,11 @@ $ErrorActionPreference = 'Stop'
 
 $package = '@involvex/youtube-music-cli'
 
-if (Get-Command npm -ErrorAction SilentlyContinue) {
-	npm install -g $package
-} elseif (Get-Command bun -ErrorAction SilentlyContinue) {
-	bun install -g $package
-} else {
-	throw "npm or bun is required to install $package."
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+	Write-Error "bun is required to run $package. Install bun: https://bun.sh"
+	exit 1
 }
+
+bun install -g $package
 
 Write-Host 'youtube-music-cli installed. Run: youtube-music-cli'

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = 'Stop'
 $package = '@involvex/youtube-music-cli'
 
 if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
-	Write-Error "bun is required to run $package. Install bun: https://bun.sh"
+	Write-Error "bun is required to run $package. Install bun: https://bun.sh" -ErrorAction Continue
 	exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,13 +3,12 @@ set -euo pipefail
 
 PACKAGE="@involvex/youtube-music-cli"
 
-if command -v npm >/dev/null 2>&1; then
-  npm install -g "$PACKAGE"
-elif command -v bun >/dev/null 2>&1; then
-  bun install -g "$PACKAGE"
-else
-  echo "Error: npm or bun is required to install ${PACKAGE}." >&2
+if ! command -v bun >/dev/null 2>&1; then
+  echo "Error: bun is required to run ${PACKAGE}." >&2
+  echo "Install bun: https://bun.sh" >&2
   exit 1
 fi
+
+bun install -g "$PACKAGE"
 
 echo "youtube-music-cli installed. Run: youtube-music-cli"


### PR DESCRIPTION
## Description

The `install.sh` script installs the package via npm first, but the CLI binary uses a `#!/usr/bin/env bun` shebang and the build targets bun (`--target bun`). Users without bun get a successful install but a non-functional CLI that immediately fails with `env: 'bun': No such file or directory`.

This PR replaces the npm-first install logic with a bun availability check and a clear error message pointing to https://bun.sh when bun is missing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

- [x] Tests pass locally (`bun run test`)
- [x] Manual testing steps performed
- [ ] Added new tests for the feature/fix

**Steps to verify:**
1. Ensure `bun` is **not** installed
2. Run `bash scripts/install.sh`
3. Confirm: error message with install link is shown, script exits with code 1
4. Install `bun`, re-run `bash scripts/install.sh`
5. Confirm: package installs successfully via `bun install -g`

## Checklist

- [x] My code follows the project's code style
- [x] I have run `bun run lint` and `bun run typecheck`
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally

## Additional Notes

Closes #27

## Summary by Sourcery

Bug Fixes:
- Prevent successful installation on systems without Bun by failing early with a clear error message and installation link.