### PR TITLE
fix(install): require bun in install scripts to match runtime dependency

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,16 +72,20 @@ sudo apt install yt-dlp
 
 ## Installation
 
-### npm (Recommended)
+### Bun (Recommended)
 
-```bash
-npm install -g @involvex/youtube-music-cli
-```
-
-### Bun
+> **Note:** bun is required at runtime. Install it from [bun.sh](https://bun.sh) before proceeding.
 
 ```bash
 bun install -g @involvex/youtube-music-cli
+```
+
+### npm
+
+> **Note:** bun must still be installed on your system — the CLI entry point uses `#!/usr/bin/env bun`. npm only manages the package download.
+
+```bash
+npm install -g @involvex/youtube-music-cli
 ```
 
 ### Homebrew

--- a/readme.md
+++ b/readme.md
@@ -98,16 +98,20 @@ sudo dnf install mpv yt-dlp
 
 ## Installation
 
-### npm (Recommended)
+### Bun (Recommended)
 
-```bash
-npm install -g @involvex/youtube-music-cli
-```
-
-### Bun
+> **Note:** bun is required at runtime. Install it from [bun.sh](https://bun.sh) before proceeding.
 
 ```bash
 bun install -g @involvex/youtube-music-cli
+```
+
+### npm
+
+> **Note:** bun must still be installed on your system — the CLI entry point uses `#!/usr/bin/env bun`. npm only manages the package download.
+
+```bash
+npm install -g @involvex/youtube-music-cli
 ```
 
 ### Homebrew

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,12 +2,12 @@ $ErrorActionPreference = 'Stop'
 
 $package = '@involvex/youtube-music-cli'
 
-if (Get-Command npm -ErrorAction SilentlyContinue) {
-	npm install -g $package
-} elseif (Get-Command bun -ErrorAction SilentlyContinue) {
-	bun install -g $package
-} else {
-	throw "npm or bun is required to install $package."
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+	Write-Host "Error: bun is required to install $package." -ForegroundColor Red
+	Write-Host 'Install bun from https://bun.sh' -ForegroundColor Red
+	exit 1
 }
+
+bun install -g $package
 
 Write-Host 'youtube-music-cli installed. Run: youtube-music-cli'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,13 +3,12 @@ set -euo pipefail
 
 PACKAGE="@involvex/youtube-music-cli"
 
-if command -v npm >/dev/null 2>&1; then
-  npm install -g "$PACKAGE"
-elif command -v bun >/dev/null 2>&1; then
-  bun install -g "$PACKAGE"
-else
-  echo "Error: npm or bun is required to install ${PACKAGE}." >&2
+if ! command -v bun >/dev/null 2>&1; then
+  echo "Error: bun is required to install ${PACKAGE}." >&2
+  echo "Install bun from https://bun.sh" >&2
   exit 1
 fi
+
+bun install -g "$PACKAGE"
 
 echo "youtube-music-cli installed. Run: youtube-music-cli"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes #27 — `install.sh` and `install.ps1` previously preferred npm when available, but the published CLI binary uses `#!/usr/bin/env bun` and is built with `--target bun`. Users with npm but no bun got a successful install that immediately failed at launch with `env: 'bun': No such file or directory`.

Both install scripts now require bun upfront, fail fast with a clear error pointing to https://bun.sh, and install via `bun install -g`.

Documentation in `readme.md` and `docs/getting-started.md` was updated to list Bun as the recommended install method and note that bun is required at runtime even when using npm.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

- [x] Tests pass locally (`bun run test`)
- [x] Manual testing steps performed
- [ ] Added new tests for the feature/fix

**Steps to verify:**

1. Ensure `bun` is **not** on PATH
2. Run `bash scripts/install.sh`
3. Confirm: error message with install link is shown, script exits with code 1
4. Install `bun`, re-run `bash scripts/install.sh`
5. Confirm: package installs successfully via `bun install -g`

## Checklist

- [x] My code follows the project's code style
- [x] I have run `bun run lint` and `bun run typecheck`
- [x] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally

## Additional Notes

Closes #27
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e34cae4-426f-46ee-b402-2369bf68f7f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e34cae4-426f-46ee-b402-2369bf68f7f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Require Bun as the installer and runtime dependency for the CLI and update documentation accordingly.

Bug Fixes:
- Ensure installation scripts fail fast with a clear error when Bun is not available and install the CLI via Bun globally instead of preferring npm.

Documentation:
- Update installation instructions to recommend Bun as the primary install method and clarify that Bun is required at runtime even when installing with npm.