### PR TITLE
fix(player): await in-flight IPC connection in resume() to prevent tr…

### DIFF
--- a/source/services/player/player.service.ts
+++ b/source/services/player/player.service.ts
@@ -172,6 +172,7 @@ class PlayerService {
 	private ipcConnectRetries = 0;
 	private readonly maxIpcRetries = 10;
 	private ipcConnectGeneration = 0;
+	private ipcConnectPending: Promise<void> | null = null;
 	private pendingIpcTimers: ReturnType<typeof setTimeout>[] = [];
 	private currentTrackId: string | null = null; // Track currently playing
 	private playSessionId = 0; // Incremented per play() call for unique IPC paths
@@ -653,12 +654,16 @@ class PlayerService {
 				const ipcDelay = process.platform === 'win32' ? 500 : 200;
 				const connectGeneration = this.ipcConnectGeneration;
 				this.scheduleIpcTimer(ipcDelay, connectGeneration, () => {
-					this.connectIpc(playUrl)
+					const pending = this.connectIpc(playUrl);
+					this.ipcConnectPending = pending;
+					pending
 						.then(() => {
 							// IPC connected and loadfile sent - playback starting
+							this.ipcConnectPending = null;
 							handleSuccess();
 						})
 						.catch(error => {
+							this.ipcConnectPending = null;
 							logger.warn('PlayerService', 'Failed to connect IPC', {
 								error: formatError(error),
 							});
@@ -758,14 +763,27 @@ class PlayerService {
 		}
 	}
 
-	resume(): void {
+	async resume(): Promise<void> {
 		logger.debug('PlayerService', 'resume() called', {
 			isPlaying: this.isPlaying,
 			hasIpcSocket: Boolean(this.ipcSocket),
 			ipcDestroyed: this.ipcSocket?.destroyed ?? true,
 			hasMpvProcess: Boolean(this.mpvProcess),
+			hasPendingConnect: Boolean(this.ipcConnectPending),
 			currentTrackId: this.currentTrackId,
 		});
+
+		// An IPC connection may still be in flight (mpv is spawned but the
+		// socket connects ~200ms later). Wait for it instead of falling
+		// through to the restart fallback, which would replay the track
+		// from the beginning.
+		if (this.ipcConnectPending) {
+			try {
+				await this.ipcConnectPending;
+			} catch {
+				// Connection genuinely failed; fall through to the fallback below.
+			}
+		}
 
 		if (this.ipcSocket && !this.ipcSocket.destroyed) {
 			this.isPlaying = true;
@@ -775,6 +793,7 @@ class PlayerService {
 					this.sendIpcCommand(['set_property', 'volume', this.currentVolume]);
 				}, 100);
 			}
+
 			return;
 		}
 
@@ -798,6 +817,7 @@ class PlayerService {
 		});
 
 		this.invalidateIpcConnect();
+		this.ipcConnectPending = null;
 		this.playGeneration++;
 		this.destroyIpcSocket();
 


### PR DESCRIPTION
## Description

Pausing and then resuming restarts the current track from the beginning instead of resuming from the paused position. This reproduces consistently on Linux.

`PlayerService.resume()` decides between a real resume and a restart fallback by checking the instantaneous state of the IPC socket:

```ts
if (this.ipcSocket && !this.ipcSocket.destroyed) {
    this.sendIpcCommand(['set_property', 'pause', false]);
    return;
}

if (this.currentUrl) {
    logger.info('PlayerService', 'Resume fallback: restarting track');
    void this.play(this.currentUrl, {volume: this.currentVolume});
    return;
}
```

The fallback exists for the case where the IPC session has been lost. However, `play()` schedules the IPC connection with a deliberate delay:

```ts
const ipcDelay = process.platform === 'win32' ? 500 : 200;
```

During that window `this.ipcSocket` is still `null` — the socket is not dead, it has not been created yet. `resume()` cannot distinguish "session lost" from "session not ready", so it takes the fallback branch and replays the track from the start.

**Evidence** — debug log from a single pause → play cycle (Linux, Node 22.23.1, v0.0.96):
53.041  [PlayerReducer]  RESUME action received
53.054  [PlayerService]  Spawning mpv process with IPC   ipcPath: /tmp/mpvsocket-1560398-8
53.059  [PlayerService]  resume() called   hasIpcSocket: false, ipcDestroyed: true
53.059  [PlayerService]  Resume fallback: restarting track
53.060  [PlayerService]  Spawning mpv process with IPC   ipcPath: /tmp/mpvsocket-1560398-9
53.265  [PlayerService]  IPC socket connected

`resume()` is invoked 5ms after the spawn; the socket only connects 206ms later. The stack trace on the fallback line confirms the chain `resume() → play() → stop()`, where `stop()` destroys the socket and a fresh mpv process is spawned.

**Fix** — track the in-flight connection promise and have `resume()` await it before inspecting the socket. If the connection genuinely fails, the existing fallback still applies unchanged.

- Add `private ipcConnectPending: Promise<void> | null = null`
- `play()` stores the `connectIpc()` promise and clears it on settle (both success and failure)
- `resume()` becomes `async` and awaits any pending connection before the socket check
- `stop()` clears the pending reference alongside the existing invalidation

The change is additive: when no connection is in flight, behaviour is identical to before.

## Type of change

Please mark relevant options with an `x`:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

Please describe the tests that you ran to verify your changes:

- [ ] Tests pass locally (`bun run test`)
- [x] Manual testing steps performed
- [ ] Added new tests for the feature/fix

Provide testing instructions:

Manual testing on Linux (mpv via IPC), verified against `~/.youtube-music-cli/debug.log`:

1. Start any track, let it play for a few seconds, press `Space` to pause, press `Space` again to resume.
   - **Before:** track restarts from 0:00; `Resume fallback: restarting track` appears in the log on every cycle.
   - **After:** track resumes from the paused position; the fallback line no longer appears.
2. Start a track and press `Space` within the first ~200ms (inside the IPC connection window).
   - **Before:** track restarts.
   - **After:** resumes correctly; the log shows `hasPendingConnect: true`.

## Checklist

- [x] My code follows the project's code style
- [ ] I have run `bun run lint` and `bun run typecheck`
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally

## Additional Notes

`resume()` changes from `void` to `Promise<void>`. This is source-compatible with the existing call sites, which invoke it fire-and-forget; callers could be updated to `void playerService.resume()` for explicitness, but that is left out to keep the diff minimal.

Happy to add a regression test if you can point me at the preferred approach for testing IPC timing — the race is timing-dependent and I did not want to introduce a flaky test unprompted.

## Summary by Sourcery

Ensure player resume waits for any in-flight IPC connection before deciding between resuming playback or restarting the track.

Bug Fixes:
- Fix resume behaviour so tracks resume from the paused position instead of restarting when the IPC connection is still being established.

Enhancements:
- Track pending IPC connection attempts on the player service and expose their state in logging.
- Make the player resume method asynchronous to accommodate awaiting IPC connection completion.