### PR TITLE
fix: add bin.install_symlink for youtube-music-cli and ymc

### DIFF
--- a/Formula/youtube-music-cli.rb
+++ b/Formula/youtube-music-cli.rb
@@ -9,6 +9,8 @@ class YoutubeMusicCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
+    bin.install_symlink libexec/"bin/youtube-music-cli"
+    bin.install_symlink libexec/"bin/ymc"
   end
 
   test do


### PR DESCRIPTION
Formula was missing bin.install_symlink, npm install with std_npm_args puts binaries in libexec/bin but they were never linked to the Homebrew prefix bin.