### PR TITLE
fix: link binaries from libexec/bin to Homebrew prefix bin

### DIFF
--- a/Formula/youtube-music-cli.rb
+++ b/Formula/youtube-music-cli.rb
@@ -9,6 +9,8 @@ class YoutubeMusicCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
+    bin.install_symlink libexec/"bin/youtube-music-cli"
+    bin.install_symlink libexec/"bin/ymc"
   end
 
   test do


### PR DESCRIPTION
npm install with std_npm_args puts binaries under libexec/bin, but they were never symlinked to the Homebrew prefix bin. This adds bin.install_symlink for both youtube-music-cli and ymc.

## Summary by Sourcery

Bug Fixes:
- Symlink youtube-music-cli and ymc executables from libexec/bin into the Homebrew prefix bin so installed commands are available on PATH.