### PR TITLE
fix mpv not found on Windows

### DIFF
--- a/source/services/player/dependency-check.service.ts
+++ b/source/services/player/dependency-check.service.ts
@@ -11,10 +11,6 @@ export type InstallPlan = {
 const REQUIRED_DEPENDENCIES: PlaybackDependency[] = ['mpv', 'yt-dlp'];
 
 function getDependencyExecutable(dependency: PlaybackDependency): string {
-	if (process.platform === 'win32') {
-		return dependency === 'mpv' ? 'mpv.exe' : 'yt-dlp.exe';
-	}
-
 	return dependency;
 }
 


### PR DESCRIPTION
## Description

Removes the addition of the ".exe" suffix for the dependency executables, since it's not needed on Windows.

Apparently, the mpv software on Windows comes with two executables:
- mpv.exe is the heavy one, that has everything, except for the console output,
that is, it returns nothing when ran with the --version flag.
- mpv.com seems to be the console one, which is the one that returns the version data when ran with the --version flag.

Because the app was running "mpv.exe --version" and it returned nothing, it was throwing the "mpv not found" error. When running "mpv --version" without the ".exe", it correctly defaults to the "mpv.com" file which contains the console output implementation, which returns the version data when the --version flag is passed.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Additional data

I would love to know why this was here in the first place

## Summary by Sourcery

Bug Fixes:
- Fix dependency detection on Windows by using the executable names without appending an unnecessary `.exe` suffix.