### PR TITLE
fix: Homebrew CLI symlinks

### DIFF
--- a/Formula/youtube-music-cli.rb
+++ b/Formula/youtube-music-cli.rb
@@ -9,6 +9,7 @@ class YoutubeMusicCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
+    bin.install_symlink Dir[libexec/"bin/*"]
   end
 
   test do


### PR DESCRIPTION
## Description

Fix the Homebrew formula so the npm-installed CLI binaries are exposed through Homebrew's `bin` directory.

Previously, `brew install youtube-music-cli` installed both `youtube-music-cli` and `ymc` under `libexec/bin`, but did not link them into Homebrew's executable path. As a result, the installation succeeded while running either command returned `command not found`.

This change adds:

```ruby
bin.install_symlink Dir[libexec/"bin/*"]
```

so both CLI entry points are available after installation.

## Type of change

Please mark relevant options with an `x`:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Refactoring (no functional changes)
* [ ] Performance improvement

## Testing

Please describe the tests that you ran to verify your changes:

* [ ] Tests pass locally (`bun run test`)
* [x] Manual testing steps performed
* [ ] Added new tests for the feature/fix

Provide testing instructions:

1. Install the formula:

   ```sh
   brew tap involvex/youtube-music-cli https://github.com/involvex/youtube-music-cli.git
   brew install youtube-music-cli
   ```

2. Before this fix, the package is installed successfully, but the binaries only exist under:

   ```sh
   $(brew --prefix youtube-music-cli)/libexec/bin
   ```

   and running:

   ```sh
   youtube-music-cli
   ```

   results in:

   ```text
   zsh: command not found: youtube-music-cli
   ```

3. With this fix, the npm binaries are symlinked into the formula's `bin` directory, making both commands available:

   ```sh
   youtube-music-cli --help
   ymc --help
   ```

The existing Homebrew formula test already expects `#{bin}/youtube-music-cli` to exist, so this also makes the install behavior consistent with the existing test.

## Checklist

* [x] My code follows the project's code style
* [ ] I have run `bun run lint` and `bun run typecheck`
* [ ] I have updated the documentation accordingly
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing tests pass locally

## Additional Notes

This only changes the Homebrew packaging behavior. It does not modify the application itself.

The npm package already creates both `youtube-music-cli` and `ymc` entry points under `libexec/bin`; the formula was simply not exposing them through Homebrew's standard `bin` directory.

## Summary by Sourcery

Bug Fixes:
- Expose the npm-installed `youtube-music-cli` and `ymc` commands through Homebrew’s standard executable path.