### PR TITLE
fix: make Escape/back navigation and keyboard controls reliable

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -55,15 +55,15 @@ These work from any screen.
 
 ## Search
 
-| Key        | Action                      |
-| ---------- | --------------------------- |
-| `/`        | Focus search input          |
-| `Enter`    | Execute search              |
-| `Esc`      | Clear search / Close        |
-| `]/` / `[` | More / fewer search results |
-| `W`        | Add track to playback queue |
-| `Y`        | Play track next in queue    |
-| `Shift+H`  | Queue & History view        |
+| Key        | Action                          |
+| ---------- | ------------------------------- |
+| `/`        | Focus search input              |
+| `Enter`    | Execute search                  |
+| `Esc`      | Back (results → typing → leave) |
+| `]/` / `[` | More / fewer search results     |
+| `W`        | Add track to playback queue     |
+| `Y`        | Play track next in queue        |
+| `Shift+H`  | Queue & History view            |
 
 ## Playlist
 

--- a/source/components/ai/AIChatView.tsx
+++ b/source/components/ai/AIChatView.tsx
@@ -6,6 +6,7 @@ import type {ReactNode} from 'react';
 import {useChat} from '../../stores/chat.store.tsx';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
 import {VIEW} from '../../utils/constants.ts';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {getConfigService} from '../../services/config/config.service.ts';
@@ -14,6 +15,13 @@ export default function AIChatView(): ReactNode {
 	const {messages, isProcessing, error, sendMessage, isConfigured} = useChat();
 	const {dispatch} = useNavigation();
 	const [input, setInput] = useState('');
+
+	const llmEnabled = getConfigService().getLLMEnabled();
+	// The chat input is focused while this view is active: block global
+	// shortcuts so typing (e.g. 'q', space) doesn't trigger app actions.
+	// Escape still leaves via the bypass BACK handler below.
+	const chatActive = llmEnabled && isConfigured;
+	useKeyboardBlocker(chatActive);
 
 	const handleSubmit = async (): Promise<void> => {
 		if (!input.trim() || isProcessing) return;
@@ -27,8 +35,13 @@ export default function AIChatView(): ReactNode {
 	};
 
 	useKeyBinding(resolveKeybinding('SELECT'), goToSettings);
-
-	const llmEnabled = getConfigService().getLLMEnabled();
+	useKeyBinding(
+		resolveKeybinding('BACK'),
+		() => {
+			dispatch({category: 'GO_BACK'});
+		},
+		{bypassBlock: true},
+	);
 
 	if (!llmEnabled) {
 		return (

--- a/source/components/auth/LoginView.tsx
+++ b/source/components/auth/LoginView.tsx
@@ -91,8 +91,9 @@ export default function LoginView() {
 		}
 	}, [status.loggedIn]);
 
-	// Allow R key to retry login
-	useKeyBinding(['R'], () => {
+	// Allow r key to retry login (lowercase: uppercase would imply Shift+R,
+	// which is already the global resume-background shortcut).
+	useKeyBinding(['r'], () => {
 		if (loginState === 'error' || showCookieFallback) {
 			setLoginState('idle');
 			setError(null);

--- a/source/components/common/Help.tsx
+++ b/source/components/common/Help.tsx
@@ -127,7 +127,8 @@ export default function Help() {
 						<Text> | </Text>
 						<Text color={theme.colors.text}>Shift+D</Text> - Download selection
 						<Text> | </Text>
-						<Text color={theme.colors.text}>Esc</Text> - Clear Search
+						<Text color={theme.colors.text}>Esc</Text> - Back (staged: close
+						dialog, then view)
 						<Text> | </Text>
 						<Text color={theme.colors.text}>Shift+H</Text> - Queue & History
 						<Text> | </Text>
@@ -165,7 +166,7 @@ export default function Help() {
 				</Text>
 				<Box paddingX={2}>
 					<Text>
-						<Text color={theme.colors.text}>M</Text> - Toggle Mini Player
+						<Text color={theme.colors.text}>v</Text> - Toggle Mini Player
 						<Text> | </Text>
 						<Text color={theme.colors.text}>l</Text> - Lyrics
 						<Text> | </Text>

--- a/source/components/config/KeybindingsLayout.tsx
+++ b/source/components/config/KeybindingsLayout.tsx
@@ -1,8 +1,11 @@
 // Custom keybindings editor — shows all actions and their bound keys
 import {Box, Text, useInput} from 'ink';
-import {useState} from 'react';
+import {useState, useCallback} from 'react';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
+import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
 import {getConfigService} from '../../services/config/config.service.ts';
 import {KEYBINDINGS} from '../../utils/constants.ts';
 
@@ -91,8 +94,14 @@ export default function KeybindingsLayout() {
 	const [statusMessage, setStatusMessage] = useState('');
 	const [conflictWarning, setConflictWarning] = useState<string | null>(null);
 
-	useInput((input, key) => {
-		if (isCapturing) {
+	// While capturing a new binding, block the global registry so the
+	// pressed keys don't trigger app actions (e.g. 'r' resetting AND
+	// toggling repeat). The capture handler below uses Ink's isActive gate so
+	// it only listens during capture — no double-handling outside it.
+	useKeyboardBlocker(isCapturing);
+
+	useInput(
+		(input, key) => {
 			// Build key string from the pressed key
 			const parts: string[] = [];
 			if (key.ctrl) parts.push('ctrl');
@@ -136,56 +145,77 @@ export default function KeybindingsLayout() {
 			setIsCapturing(false);
 			setStatusMessage(`Bound ${entry.action} to "${newKey}"`);
 			setConflictWarning(null);
-			return;
-		}
+		},
+		{isActive: isCapturing},
+	);
 
-		if (key.escape) {
-			dispatch({category: 'GO_BACK'});
-			return;
-		}
+	const navigateUp = useCallback(() => {
+		if (isCapturing) return;
+		setSelectedIndex(i => Math.max(0, i - 1));
+	}, [isCapturing]);
 
-		if (key.upArrow || input === 'k') {
-			setSelectedIndex(i => Math.max(0, i - 1));
-		} else if (key.downArrow || input === 'j') {
-			setSelectedIndex(i => Math.min(entries.length - 1, i + 1));
-		} else if (key.return) {
-			if (conflictWarning) {
-				// User confirmed override despite conflict
-				const entry = entries[selectedIndex];
-				if (!entry) return;
+	const navigateDown = useCallback(() => {
+		if (isCapturing) return;
+		setSelectedIndex(i => Math.min(entries.length - 1, i + 1));
+	}, [isCapturing, entries.length]);
 
-				// Extract the key from the warning message
-				const match = conflictWarning.match(/"([^"]+)"/);
-				if (match && match[1]) {
-					const newKey = match[1];
-					getConfigService().setKeybinding(entry.action, [newKey]);
-					setEntries(buildEntries());
-					setIsCapturing(false);
-					setStatusMessage(
-						`Bound ${entry.action} to "${newKey}" (overrode conflict)`,
-					);
-					setConflictWarning(null);
-				}
-			} else {
-				setIsCapturing(true);
-				setStatusMessage('Press any key to bind...');
-				setConflictWarning(null);
-			}
-		} else if (input === 'r') {
-			// Reset selected binding to default
+	const handleSelect = useCallback(() => {
+		if (isCapturing) return;
+		if (conflictWarning) {
+			// User confirmed override despite conflict
 			const entry = entries[selectedIndex];
 			if (!entry) return;
-			const defaultKeys = KEYBINDINGS[entry.action as keyof typeof KEYBINDINGS];
-			if (defaultKeys) {
-				getConfigService().setKeybinding(entry.action, [
-					...defaultKeys,
-				] as string[]);
+
+			// Extract the key from the warning message
+			const match = conflictWarning.match(/"([^"]+)"/);
+			if (match?.[1]) {
+				const newKey = match[1];
+				getConfigService().setKeybinding(entry.action, [newKey]);
 				setEntries(buildEntries());
-				setStatusMessage(`Reset ${entry.action} to default`);
+				setIsCapturing(false);
+				setStatusMessage(
+					`Bound ${entry.action} to "${newKey}" (overrode conflict)`,
+				);
 				setConflictWarning(null);
 			}
+		} else {
+			setIsCapturing(true);
+			setStatusMessage('Press any key to bind...');
+			setConflictWarning(null);
 		}
-	});
+	}, [isCapturing, conflictWarning, entries, selectedIndex]);
+
+	const handleReset = useCallback(() => {
+		if (isCapturing) return;
+		// Reset selected binding to default
+		const entry = entries[selectedIndex];
+		if (!entry) return;
+		const defaultKeys = KEYBINDINGS[entry.action as keyof typeof KEYBINDINGS];
+		if (defaultKeys) {
+			getConfigService().setKeybinding(entry.action, [
+				...defaultKeys,
+			] as string[]);
+			setEntries(buildEntries());
+			setStatusMessage(`Reset ${entry.action} to default`);
+			setConflictWarning(null);
+		}
+	}, [isCapturing, entries, selectedIndex]);
+
+	const goBack = useCallback(() => {
+		if (isCapturing) {
+			setIsCapturing(false);
+			setStatusMessage('Cancelled');
+			setConflictWarning(null);
+			return;
+		}
+		dispatch({category: 'GO_BACK'});
+	}, [isCapturing, dispatch]);
+
+	useKeyBinding(resolveKeybinding('UP'), navigateUp);
+	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
+	useKeyBinding(resolveKeybinding('SELECT'), handleSelect);
+	useKeyBinding(['r'], handleReset);
+	useKeyBinding(resolveKeybinding('BACK'), goBack, {bypassBlock: true});
 
 	return (
 		<Box flexDirection="column" padding={1}>

--- a/source/components/config/KeybindingsLayout.tsx
+++ b/source/components/config/KeybindingsLayout.tsx
@@ -3,7 +3,7 @@ import {Box, Text, useInput} from 'ink';
 import {useState, useCallback} from 'react';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
-import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useKeyBinding, isEscapeKey} from '../../hooks/useKeyboard.ts';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
 import {getConfigService} from '../../services/config/config.service.ts';
@@ -116,7 +116,9 @@ export default function KeybindingsLayout() {
 			else if (key.return) keyName = 'enter';
 			else if (key.tab) keyName = 'tab';
 			else if (key.backspace || key.delete) keyName = 'backspace';
-			else if (key.escape) {
+			else if (isEscapeKey(input, key)) {
+				// Covers terminals that deliver Escape as a raw ESC byte
+				// without setting Ink's key.escape flag.
 				setIsCapturing(false);
 				setStatusMessage('Cancelled');
 				setConflictWarning(null);

--- a/source/components/favorites/FavoritesList.tsx
+++ b/source/components/favorites/FavoritesList.tsx
@@ -3,6 +3,7 @@ import {Box, Text} from 'ink';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useFavorites} from '../../stores/favorites.store.tsx';
 import {usePlayer} from '../../hooks/usePlayer.ts';
+import {useNavigation} from '../../hooks/useNavigation.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {ICONS} from '../../utils/icons.ts';
@@ -11,6 +12,7 @@ import {useTerminalSize} from '../../hooks/useTerminalSize.ts';
 
 export default function FavoritesList() {
 	const {theme} = useTheme();
+	const {dispatch} = useNavigation();
 	const {favorites, removeFavorite} = useFavorites();
 	const {play, dispatch: playerDispatch, addToQueue, playNext} = usePlayer();
 	const {columns, rows} = useTerminalSize();
@@ -68,6 +70,9 @@ export default function FavoritesList() {
 	}, [favorites, selectedIndex, removeFavorite]);
 
 	// Key bindings
+	useKeyBinding(resolveKeybinding('BACK'), () => {
+		dispatch({category: 'GO_BACK'});
+	});
 	useKeyBinding(resolveKeybinding('UP'), navigateUp);
 	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
 	useKeyBinding(resolveKeybinding('SELECT'), playSelected);

--- a/source/components/import/ImportLayout.tsx
+++ b/source/components/import/ImportLayout.tsx
@@ -1,11 +1,12 @@
 // Import layout component for playlist import
-import {useState, useCallback, useEffect} from 'react';
+import {useState, useCallback} from 'react';
 import {Box, Text} from 'ink';
 import TextInput from 'ink-text-input';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
-import {KEYBINDINGS} from '../../utils/constants.ts';
+import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {getImportService} from '../../services/import/import.service.ts';
 import type {ImportSource, ImportProgress} from '../../types/import.types.ts';
 import ImportProgressComponent from './ImportProgress.tsx';
@@ -34,29 +35,6 @@ export default function ImportLayout() {
 		errors: string[];
 	} | null>(null);
 	const [error, setError] = useState<string | null>(null);
-
-	const goBack = useCallback(() => {
-		if (step === 'source') {
-			dispatch({category: 'GO_BACK'});
-		} else if (step === 'url') {
-			setStep('source');
-		} else if (step === 'name') {
-			setStep('url');
-		} else if (step === 'result') {
-			setStep('source');
-			setResult(null);
-		}
-	}, [step, dispatch]);
-
-	const selectSource = useCallback(() => {
-		setStep('url');
-	}, []);
-
-	const submitUrl = useCallback(() => {
-		if (url.trim()) {
-			setStep('name');
-		}
-	}, [url]);
 
 	const startImport = useCallback(async () => {
 		setStep('importing');
@@ -89,48 +67,59 @@ export default function ImportLayout() {
 		}
 	}, [selectedSource, url, customName, importService]);
 
+	const goBack = useCallback(() => {
+		if (step === 'source') {
+			dispatch({category: 'GO_BACK'});
+		} else if (step === 'url') {
+			setStep('source');
+		} else if (step === 'name') {
+			// Name is optional: Escape skips it and starts the import.
+			void startImport();
+		} else if (step === 'result') {
+			setStep('source');
+			setResult(null);
+		}
+	}, [step, dispatch, startImport]);
+
+	const selectSource = useCallback(() => {
+		setStep('url');
+	}, []);
+
+	const submitUrl = useCallback(() => {
+		if (url.trim()) {
+			setStep('name');
+		}
+	}, [url]);
+
 	const submitName = useCallback(() => {
 		startImport();
 	}, [startImport]);
 
 	// Keyboard bindings
-	useKeyBinding(KEYBINDINGS.UP, () => {
+	useKeyBinding(resolveKeybinding('UP'), () => {
 		if (step === 'source') {
 			setSelectedSource(prev => Math.max(0, prev - 1));
 		}
 	});
 
-	useKeyBinding(KEYBINDINGS.DOWN, () => {
+	useKeyBinding(resolveKeybinding('DOWN'), () => {
 		if (step === 'source') {
 			setSelectedSource(prev => Math.min(SOURCES.length - 1, prev + 1));
 		}
 	});
 
-	useKeyBinding(KEYBINDINGS.SELECT, () => {
+	useKeyBinding(resolveKeybinding('SELECT'), () => {
 		if (step === 'source') selectSource();
 		else if (step === 'url') submitUrl();
 		else if (step === 'name') submitName();
 		else if (step === 'result') goBack();
 	});
 
-	useKeyBinding(KEYBINDINGS.BACK, goBack);
-
-	// Escape key for skip name
-	useEffect(() => {
-		if (step === 'name') {
-			const handleEscape = () => {
-				startImport();
-			};
-
-			const stdin = process.stdin;
-			stdin.on('keypress', handleEscape);
-
-			return () => {
-				stdin.off('keypress', handleEscape);
-			};
-		}
-		return undefined;
-	}, [step, startImport]);
+	// Block global shortcuts while typing the URL/name so pasted text can't
+	// trigger app actions. Escape still works via the bypass BACK handler.
+	const isTypingStep = step === 'url' || step === 'name';
+	useKeyboardBlocker(isTypingStep);
+	useKeyBinding(resolveKeybinding('BACK'), goBack, {bypassBlock: true});
 
 	return (
 		<Box flexDirection="column" gap={1} paddingX={1}>
@@ -277,7 +266,9 @@ export default function ImportLayout() {
 					<Text color={theme.colors.dim}>
 						{step === 'source'
 							? '↑↓ to select, Enter to continue, Esc/q to go back'
-							: 'Enter to continue, Esc to go back'}
+							: step === 'name'
+								? 'Enter to import, Esc to skip'
+								: 'Enter to continue, Esc to go back'}
 					</Text>
 				</Box>
 			)}

--- a/source/components/layouts/ExploreLayout.tsx
+++ b/source/components/layouts/ExploreLayout.tsx
@@ -1,9 +1,11 @@
 // Explore / Genre browsing view — shows curated sections from YouTube Music
-import {Box, Text, useInput} from 'ink';
-import {useState, useEffect} from 'react';
+import {Box, Text} from 'ink';
+import {useState, useEffect, useCallback, useMemo} from 'react';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {usePlayer} from '../../hooks/usePlayer.ts';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {getMusicService} from '../../services/youtube-music/api.ts';
 import type {Track} from '../../types/youtube-music.types.ts';
 
@@ -46,29 +48,46 @@ export default function ExploreLayout() {
 	}, []);
 
 	const currentSection = sections[sectionIndex];
-	const tracks = currentSection?.tracks ?? [];
+	const tracks = useMemo(() => currentSection?.tracks ?? [], [currentSection]);
 
-	useInput((input, key) => {
-		if (key.escape) {
-			dispatch({category: 'GO_BACK'});
-			return;
-		}
+	const goToPrevSection = useCallback(() => {
+		setSectionIndex(i => Math.max(0, i - 1));
+		setTrackIndex(0);
+	}, []);
 
-		if (key.leftArrow || input === 'h') {
-			setSectionIndex(i => Math.max(0, i - 1));
-			setTrackIndex(0);
-		} else if (key.rightArrow || input === 'l') {
-			setSectionIndex(i => Math.min(sections.length - 1, i + 1));
-			setTrackIndex(0);
-		} else if (key.upArrow || input === 'k') {
-			setTrackIndex(i => Math.max(0, i - 1));
-		} else if (key.downArrow || input === 'j') {
-			setTrackIndex(i => Math.min(tracks.length - 1, i + 1));
-		} else if (key.return) {
-			const track = tracks[trackIndex];
-			if (track) play(track);
-		}
-	});
+	const goToNextSection = useCallback(() => {
+		setSectionIndex(i => Math.min(sections.length - 1, i + 1));
+		setTrackIndex(0);
+	}, [sections.length]);
+
+	const navigateUp = useCallback(() => {
+		setTrackIndex(i => Math.max(0, i - 1));
+	}, []);
+
+	const navigateDown = useCallback(() => {
+		setTrackIndex(i => Math.min(tracks.length - 1, i + 1));
+	}, [tracks.length]);
+
+	const playSelected = useCallback(() => {
+		const track = tracks[trackIndex];
+		if (track) play(track);
+	}, [tracks, trackIndex, play]);
+
+	const goBack = useCallback(() => {
+		dispatch({category: 'GO_BACK'});
+	}, [dispatch]);
+
+	useKeyBinding(resolveKeybinding('UP'), navigateUp);
+	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
+	useKeyBinding(resolveKeybinding('SELECT'), playSelected);
+	useKeyBinding(resolveKeybinding('BACK'), goBack);
+	useKeyBinding(['left'], goToPrevSection);
+	useKeyBinding(['right'], goToNextSection);
+	// Section navigation. These intentionally shadow the global single-key
+	// bindings (e.g. 'l' for lyrics) while this view is focused — dispatch is
+	// LIFO so the focused view wins and globals resume when leaving.
+	useKeyBinding(['h'], goToPrevSection);
+	useKeyBinding(['l'], goToNextSection);
 
 	return (
 		<Box flexDirection="column" padding={1}>

--- a/source/components/layouts/GenresLayout.tsx
+++ b/source/components/layouts/GenresLayout.tsx
@@ -1,8 +1,10 @@
-import {Box, Text, useInput} from 'ink';
-import {useState, useEffect} from 'react';
+import {Box, Text} from 'ink';
+import {useState, useEffect, useCallback, useMemo} from 'react';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {usePlayer} from '../../hooks/usePlayer.ts';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {getMusicService} from '../../services/youtube-music/api.ts';
 import type {Genre, Release} from '../../types/youtube-music.types.ts';
 
@@ -70,67 +72,82 @@ export default function GenresLayout() {
 	};
 
 	const currentSection = sections[sectionIndex];
-	const genres = currentSection?.genres ?? [];
+	const genres = useMemo(() => currentSection?.genres ?? [], [currentSection]);
 
-	useInput((input, key) => {
-		if (key.escape) {
-			if (viewMode === 'playlists') {
-				setViewMode('genres');
-				setPlaylists([]);
-			} else {
-				dispatch({category: 'GO_BACK'});
-			}
+	const openSelectedGenre = useCallback(() => {
+		const genre = genres[genreIndex];
+		if (genre) void loadPlaylistsForGenre(genre);
+	}, [genres, genreIndex]);
+
+	const playSelectedPlaylist = useCallback(() => {
+		const release = playlists[playlistIndex];
+		if (release?.browseId) {
+			setIsLoading(true);
+			getMusicService()
+				.getReleaseTracks(release.browseId)
+				.then(tracks => {
+					setIsLoading(false);
+					if (tracks.length > 0) {
+						playerDispatch({category: 'CLEAR_QUEUE'});
+						playerDispatch({category: 'SET_QUEUE', queue: tracks});
+						playerDispatch({category: 'PLAY', track: tracks[0]!});
+					} else {
+						setError('No tracks found in playlist');
+					}
+				})
+				.catch((err: unknown) => {
+					setIsLoading(false);
+					setError(
+						err instanceof Error
+							? err.message
+							: 'Failed to load playlist tracks',
+					);
+				});
+		}
+	}, [playlists, playlistIndex, playerDispatch]);
+
+	const goBack = useCallback(() => {
+		if (viewMode === 'playlists') {
+			setViewMode('genres');
+			setPlaylists([]);
 			return;
 		}
+		dispatch({category: 'GO_BACK'});
+	}, [viewMode, dispatch]);
 
-		if (viewMode === 'genres') {
-			if (key.leftArrow || input === 'h') {
-				setSectionIndex(i => Math.max(0, i - 1));
-				setGenreIndex(0);
-			} else if (key.rightArrow || input === 'l') {
-				setSectionIndex(i => Math.min(sections.length - 1, i + 1));
-				setGenreIndex(0);
-			} else if (key.upArrow || input === 'k') {
-				setGenreIndex(i => Math.max(0, i - 1));
-			} else if (key.downArrow || input === 'j') {
-				setGenreIndex(i => Math.min(genres.length - 1, i + 1));
-			} else if (key.return) {
-				const genre = genres[genreIndex];
-				if (genre) void loadPlaylistsForGenre(genre);
-			}
-		} else if (viewMode === 'playlists') {
-			if (key.upArrow || input === 'k') {
-				setPlaylistIndex(i => Math.max(0, i - 1));
-			} else if (key.downArrow || input === 'j') {
-				setPlaylistIndex(i => Math.min(playlists.length - 1, i + 1));
-			} else if (key.return) {
-				const release = playlists[playlistIndex];
-				if (release?.browseId) {
-					setIsLoading(true);
-					getMusicService()
-						.getReleaseTracks(release.browseId)
-						.then(tracks => {
-							setIsLoading(false);
-							if (tracks.length > 0) {
-								playerDispatch({category: 'CLEAR_QUEUE'});
-								playerDispatch({category: 'SET_QUEUE', queue: tracks});
-								playerDispatch({category: 'PLAY', track: tracks[0]!});
-							} else {
-								setError('No tracks found in playlist');
-							}
-						})
-						.catch((err: unknown) => {
-							setIsLoading(false);
-							setError(
-								err instanceof Error
-									? err.message
-									: 'Failed to load playlist tracks',
-							);
-						});
-				}
-			}
+	const inGenres = viewMode === 'genres';
+	useKeyBinding(['left'], () => {
+		if (!inGenres) return;
+		setSectionIndex(i => Math.max(0, i - 1));
+		setGenreIndex(0);
+	});
+	useKeyBinding(['right'], () => {
+		if (!inGenres) return;
+		setSectionIndex(i => Math.min(sections.length - 1, i + 1));
+		setGenreIndex(0);
+	});
+	useKeyBinding(resolveKeybinding('UP'), () => {
+		if (inGenres) {
+			setGenreIndex(i => Math.max(0, i - 1));
+		} else {
+			setPlaylistIndex(i => Math.max(0, i - 1));
 		}
 	});
+	useKeyBinding(resolveKeybinding('DOWN'), () => {
+		if (inGenres) {
+			setGenreIndex(i => Math.min(genres.length - 1, i + 1));
+		} else {
+			setPlaylistIndex(i => Math.min(playlists.length - 1, i + 1));
+		}
+	});
+	useKeyBinding(resolveKeybinding('SELECT'), () => {
+		if (inGenres) {
+			openSelectedGenre();
+		} else {
+			playSelectedPlaylist();
+		}
+	});
+	useKeyBinding(resolveKeybinding('BACK'), goBack);
 
 	return (
 		<Box flexDirection="column" padding={1}>

--- a/source/components/layouts/LyricsLayout.tsx
+++ b/source/components/layouts/LyricsLayout.tsx
@@ -1,9 +1,12 @@
 // Lyrics view layout - displays synced or plain lyrics with karaoke-style
 // word-level highlighting and a smooth color gradient sweep.
-import {useEffect, useState} from 'react';
+import {useEffect, useState, useCallback} from 'react';
 import {Box, Text} from 'ink';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {usePlayer} from '../../hooks/usePlayer.ts';
+import {useNavigation} from '../../hooks/useNavigation.ts';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {
 	getLyricsService,
 	type LyricLine,
@@ -25,7 +28,16 @@ const RESERVED_ROWS = 14;
 export default function LyricsLayout() {
 	const {theme} = useTheme();
 	const {state} = usePlayer();
+	const {dispatch} = useNavigation();
 	const {rows} = useTerminalSize();
+
+	// The footer promises "l or Esc to go back" — previously neither was
+	// bound, so both appeared dead.
+	const goBack = useCallback(() => {
+		dispatch({category: 'GO_BACK'});
+	}, [dispatch]);
+	useKeyBinding(resolveKeybinding('BACK'), goBack);
+	useKeyBinding(['l'], goBack);
 	const [lyrics, setLyrics] = useState<{
 		synced: LyricLine[] | null;
 		plain: string | null;

--- a/source/components/layouts/MainLayout.tsx
+++ b/source/components/layouts/MainLayout.tsx
@@ -195,14 +195,22 @@ function MainLayout() {
 	// Global keyboard bindings
 	useKeyBinding(resolveKeybinding('QUIT'), handleQuit);
 
-	// Esc from player view goes back (player has no native back binding)
-	const handlePlayerBack = useCallback(() => {
-		if (navState.currentView === VIEW.PLAYER) {
-			dispatch({category: 'GO_BACK'});
+	// Global back fallback (lowest priority: MainLayout registers first, and
+	// KeyboardManager dispatches LIFO, so a focused view's own BACK handler
+	// always wins and this only fires when nothing more specific handled it).
+	// Previously this only worked in the player view and swallowed Escape
+	// everywhere else, making "Esc to go back" unreliable.
+	const handleGlobalBack = useCallback(() => {
+		if (navState.playerMode === 'mini') {
+			dispatch({category: 'TOGGLE_PLAYER_MODE'});
+			return;
 		}
-	}, [navState.currentView, dispatch]);
+		dispatch({category: 'GO_BACK'});
+	}, [dispatch, navState.playerMode]);
 
-	useKeyBinding(resolveKeybinding('BACK'), handlePlayerBack);
+	useKeyBinding(resolveKeybinding('BACK'), handleGlobalBack, {
+		bypassBlock: true,
+	});
 	useKeyBinding(
 		navState.currentView === VIEW.RADIO ||
 			navState.currentView === VIEW.LIVE_STREAMS
@@ -217,7 +225,7 @@ function MainLayout() {
 	useKeyBinding(resolveKeybinding('HOME'), goToHome);
 	useKeyBinding(resolveKeybinding('SETTINGS'), goToSettings);
 	useKeyBinding(resolveKeybinding('HELP'), goToHelp);
-	useKeyBinding(['M'], togglePlayerMode);
+	useKeyBinding(['v'], togglePlayerMode);
 	useKeyBinding(['l'], goToLyrics);
 	useKeyBinding(['T'], goToTrending);
 	useKeyBinding(['e'], goToExplore);

--- a/source/components/layouts/NewReleasesLayout.tsx
+++ b/source/components/layouts/NewReleasesLayout.tsx
@@ -1,8 +1,10 @@
-import {Box, Text, useInput} from 'ink';
-import {useState, useEffect} from 'react';
+import {Box, Text} from 'ink';
+import {useState, useEffect, useCallback, useMemo} from 'react';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {usePlayer} from '../../hooks/usePlayer.ts';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {getMusicService} from '../../services/youtube-music/api.ts';
 import type {Release} from '../../types/youtube-music.types.ts';
 
@@ -45,51 +47,58 @@ export default function NewReleasesLayout() {
 	}, []);
 
 	const currentSection = sections[sectionIndex];
-	const releases = currentSection?.releases ?? [];
+	const releases = useMemo(
+		() => currentSection?.releases ?? [],
+		[currentSection],
+	);
 
-	useInput((input, key) => {
-		if (key.escape) {
-			dispatch({category: 'GO_BACK'});
-			return;
+	const playSelected = useCallback(() => {
+		const release = releases[releaseIndex];
+		if (release?.browseId) {
+			setIsLoading(true);
+			getMusicService()
+				.getReleaseTracks(release.browseId)
+				.then(tracks => {
+					setIsLoading(false);
+					if (tracks.length > 0) {
+						playerDispatch({category: 'CLEAR_QUEUE'});
+						playerDispatch({category: 'SET_QUEUE', queue: tracks});
+						playerDispatch({category: 'PLAY', track: tracks[0]!});
+					} else {
+						setError('No tracks found in release');
+					}
+				})
+				.catch((err: unknown) => {
+					setIsLoading(false);
+					setError(
+						err instanceof Error
+							? err.message
+							: 'Failed to load release tracks',
+					);
+				});
 		}
+	}, [releases, releaseIndex, playerDispatch]);
 
-		if (key.leftArrow || input === 'h') {
-			setSectionIndex(i => Math.max(0, i - 1));
-			setReleaseIndex(0);
-		} else if (key.rightArrow || input === 'l') {
-			setSectionIndex(i => Math.min(sections.length - 1, i + 1));
-			setReleaseIndex(0);
-		} else if (key.upArrow || input === 'k') {
-			setReleaseIndex(i => Math.max(0, i - 1));
-		} else if (key.downArrow || input === 'j') {
-			setReleaseIndex(i => Math.min(releases.length - 1, i + 1));
-		} else if (key.return) {
-			const release = releases[releaseIndex];
-			if (release?.browseId) {
-				setIsLoading(true);
-				getMusicService()
-					.getReleaseTracks(release.browseId)
-					.then(tracks => {
-						setIsLoading(false);
-						if (tracks.length > 0) {
-							playerDispatch({category: 'CLEAR_QUEUE'});
-							playerDispatch({category: 'SET_QUEUE', queue: tracks});
-							playerDispatch({category: 'PLAY', track: tracks[0]!});
-						} else {
-							setError('No tracks found in release');
-						}
-					})
-					.catch((err: unknown) => {
-						setIsLoading(false);
-						setError(
-							err instanceof Error
-								? err.message
-								: 'Failed to load release tracks',
-						);
-					});
-			}
-		}
+	const goBack = useCallback(() => {
+		dispatch({category: 'GO_BACK'});
+	}, [dispatch]);
+
+	useKeyBinding(['left'], () => {
+		setSectionIndex(i => Math.max(0, i - 1));
+		setReleaseIndex(0);
 	});
+	useKeyBinding(['right'], () => {
+		setSectionIndex(i => Math.min(sections.length - 1, i + 1));
+		setReleaseIndex(0);
+	});
+	useKeyBinding(resolveKeybinding('UP'), () => {
+		setReleaseIndex(i => Math.max(0, i - 1));
+	});
+	useKeyBinding(resolveKeybinding('DOWN'), () => {
+		setReleaseIndex(i => Math.min(releases.length - 1, i + 1));
+	});
+	useKeyBinding(resolveKeybinding('SELECT'), playSelected);
+	useKeyBinding(resolveKeybinding('BACK'), goBack);
 
 	return (
 		<Box flexDirection="column" padding={1}>

--- a/source/components/layouts/PluginsLayout.tsx
+++ b/source/components/layouts/PluginsLayout.tsx
@@ -3,6 +3,7 @@ import {useState, useCallback} from 'react';
 import {Box, Text} from 'ink';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {usePlugins} from '../../stores/plugins.store.tsx';
+import {useNavigation} from '../../hooks/useNavigation.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import PluginsList from '../plugins/PluginsList.tsx';
@@ -12,6 +13,7 @@ type ViewMode = 'list' | 'install' | 'details';
 
 export default function PluginsLayout() {
 	const {theme} = useTheme();
+	const {dispatch: navDispatch} = useNavigation();
 	const {
 		state,
 		dispatch,
@@ -84,6 +86,15 @@ export default function PluginsLayout() {
 	useKeyBinding(['r'], removePlugin);
 	useKeyBinding(['u'], handleUpdate);
 	useKeyBinding(['i'], openInstall);
+	// Advertised in the footer as Esc=Back. The install dialog (when open)
+	// registers its own BACK handler later, so LIFO dispatch lets it win.
+	useKeyBinding(resolveKeybinding('BACK'), () => {
+		if (viewMode === 'list') {
+			navDispatch({category: 'GO_BACK'});
+		} else {
+			closeInstall();
+		}
+	});
 
 	// Show install dialog
 	if (viewMode === 'install') {

--- a/source/components/layouts/SearchLayout.tsx
+++ b/source/components/layouts/SearchLayout.tsx
@@ -11,6 +11,7 @@ import type {
 import {useTheme} from '../../hooks/useTheme.ts';
 import SearchBar from '../search/SearchBar.tsx';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {VIEW} from '../../utils/constants.ts';
 import {Box, Text} from 'ink';
@@ -51,6 +52,10 @@ function SearchLayout() {
 	const lastAutoSearchedQueryRef = useRef<string | null>(null);
 	const [editingFilter, setEditingFilter] = useState<FilterField | null>(null);
 	const [filterDraft, setFilterDraft] = useState('');
+
+	// Block global shortcuts while editing a filter value so typing doesn't
+	// trigger app actions. Escape still works via the bypass BACK handler.
+	useKeyboardBlocker(editingFilter !== null);
 
 	const describeFilterValue = (value?: string) =>
 		value?.trim() ? value.trim() : 'Any';
@@ -204,7 +209,9 @@ function SearchLayout() {
 		});
 	}, [navState.searchQuery, navState.hasSearched, performSearch]);
 
-	// Handle going back
+	// Handle going back (staged): cancel filter edit first, then return from
+	// results to typing, then leave the search view. Registered with
+	// bypassBlock so Escape works while the search/filter inputs are focused.
 	const goBack = useCallback(() => {
 		if (editingFilter) {
 			setEditingFilter(null);
@@ -219,13 +226,7 @@ function SearchLayout() {
 		}
 	}, [editingFilter, isTyping, dispatch]);
 
-	// Handle escape in search - go to home
-	const goToHome = useCallback(() => {
-		dispatch({category: 'NAVIGATE', view: VIEW.HOME});
-	}, [dispatch]);
-
-	useKeyBinding(resolveKeybinding('BACK'), goBack);
-	useKeyBinding(['escape'], goToHome, {bypassBlock: true});
+	useKeyBinding(resolveKeybinding('BACK'), goBack, {bypassBlock: true});
 
 	const handleMixCreated = useCallback((message: string) => {
 		setActionMessage(message);
@@ -377,7 +378,7 @@ function SearchLayout() {
 			)}
 			<Text color={theme.colors.dim}>
 				{isTyping
-					? 'Type to search, Enter to start, Esc to clear'
+					? 'Type to search, Enter to start, Esc back'
 					: `Arrows navigate, Enter play, W queue, Y play next, M mix, Shift+D download, ]/[ results (${navState.searchLimit}), H history, Esc type`}
 			</Text>
 		</Box>

--- a/source/components/layouts/TrendingLayout.tsx
+++ b/source/components/layouts/TrendingLayout.tsx
@@ -1,9 +1,11 @@
 // Trending tracks view — shows YouTube trending music
-import {Box, Text, useInput} from 'ink';
-import {useState, useEffect} from 'react';
+import {Box, Text} from 'ink';
+import {useState, useEffect, useCallback} from 'react';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {usePlayer} from '../../hooks/usePlayer.ts';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {getMusicService} from '../../services/youtube-music/api.ts';
 import type {Track} from '../../types/youtube-music.types.ts';
 
@@ -39,21 +41,27 @@ export default function TrendingLayout() {
 		};
 	}, []);
 
-	useInput((input, key) => {
-		if (key.escape) {
-			dispatch({category: 'GO_BACK'});
-			return;
-		}
+	const navigateUp = useCallback(() => {
+		setSelectedIndex(i => Math.max(0, i - 1));
+	}, []);
 
-		if (key.upArrow || input === 'k') {
-			setSelectedIndex(i => Math.max(0, i - 1));
-		} else if (key.downArrow || input === 'j') {
-			setSelectedIndex(i => Math.min(tracks.length - 1, i + 1));
-		} else if (key.return) {
-			const track = tracks[selectedIndex];
-			if (track) play(track);
-		}
-	});
+	const navigateDown = useCallback(() => {
+		setSelectedIndex(i => Math.min(tracks.length - 1, i + 1));
+	}, [tracks.length]);
+
+	const playSelected = useCallback(() => {
+		const track = tracks[selectedIndex];
+		if (track) play(track);
+	}, [tracks, selectedIndex, play]);
+
+	const goBack = useCallback(() => {
+		dispatch({category: 'GO_BACK'});
+	}, [dispatch]);
+
+	useKeyBinding(resolveKeybinding('UP'), navigateUp);
+	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
+	useKeyBinding(resolveKeybinding('SELECT'), playSelected);
+	useKeyBinding(resolveKeybinding('BACK'), goBack);
 
 	return (
 		<Box flexDirection="column" padding={1}>

--- a/source/components/live-streams/LiveStreamsList.tsx
+++ b/source/components/live-streams/LiveStreamsList.tsx
@@ -5,7 +5,7 @@ import {usePlayer} from '../../hooks/usePlayer.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {useTerminalSize} from '../../hooks/useTerminalSize.ts';
-import {KEYBINDINGS} from '../../utils/constants.ts';
+import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {truncate} from '../../utils/format.ts';
 import {
 	getLiveStreams,
@@ -40,10 +40,10 @@ export default function LiveStreamsList() {
 		dispatch({category: 'GO_BACK'});
 	}, [dispatch]);
 
-	useKeyBinding(KEYBINDINGS.UP, navigateUp);
-	useKeyBinding(KEYBINDINGS.DOWN, navigateDown);
-	useKeyBinding(KEYBINDINGS.SELECT, playSelected);
-	useKeyBinding(KEYBINDINGS.BACK, goBack);
+	useKeyBinding(resolveKeybinding('UP'), navigateUp);
+	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
+	useKeyBinding(resolveKeybinding('SELECT'), playSelected);
+	useKeyBinding(resolveKeybinding('BACK'), goBack);
 
 	const maxVisible = Math.max(5, termRows - 14);
 	const start = Math.max(

--- a/source/components/player/PlayerControls.tsx
+++ b/source/components/player/PlayerControls.tsx
@@ -118,10 +118,15 @@ export default function PlayerControls() {
 	useKeyBinding(resolveKeybinding('PLAY_PAUSE'), handlePlayPause);
 	useKeyBinding(resolveKeybinding('NEXT'), next);
 	useKeyBinding(resolveKeybinding('PREVIOUS'), previous);
-	useKeyBinding(['up'], volumeUp);
-	useKeyBinding(['down'], volumeDown);
-	useKeyBinding(['left'], previous);
-	useKeyBinding(['right'], next);
+	// Arrow keys adjust volume / skip tracks ONLY in the player view. This
+	// component is also mounted in list views (Favorites, Radio, Live) where
+	// Up/Down must navigate the list — previously both handlers raced and one
+	// of the two controls silently stopped working.
+	const playerView = navState.currentView === VIEW.PLAYER;
+	useKeyBinding(playerView ? ['up'] : [], volumeUp);
+	useKeyBinding(playerView ? ['down'] : [], volumeDown);
+	useKeyBinding(playerView ? ['left'] : [], previous);
+	useKeyBinding(playerView ? ['right'] : [], next);
 	useKeyBinding(resolveKeybinding('SPEED_UP'), speedUp);
 	useKeyBinding(resolveKeybinding('SPEED_DOWN'), speedDown);
 	useKeyBinding(resolveKeybinding('SHUFFLE'), toggleShuffle);

--- a/source/components/player/Suggestions.tsx
+++ b/source/components/player/Suggestions.tsx
@@ -6,12 +6,14 @@ import {usePlayer} from '../../hooks/usePlayer.ts';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
+import {useNavigation} from '../../hooks/useNavigation.ts';
 import type {Track} from '../../types/youtube-music.types.ts';
 import {truncate} from '../../utils/format.ts';
 import {getSmartRecommendations} from '../../services/youtube-music/smart-recommendations.service.ts';
 
 export default function Suggestions() {
 	const {theme} = useTheme();
+	const {dispatch} = useNavigation();
 	const {state: playerState, play} = usePlayer();
 	const {isLoading: _isLoading} = useYouTubeMusic();
 	const [suggestions, setSuggestions] = useState<Track[]>([]);
@@ -58,6 +60,9 @@ export default function Suggestions() {
 	useKeyBinding(resolveKeybinding('UP'), navigateUp);
 	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
 	useKeyBinding(resolveKeybinding('SELECT'), playSelected);
+	useKeyBinding(resolveKeybinding('BACK'), () => {
+		dispatch({category: 'GO_BACK'});
+	});
 
 	if (isLoading) {
 		return <Text color={theme.colors.accent}>Loading suggestions...</Text>;

--- a/source/components/playlist/PlaylistList.tsx
+++ b/source/components/playlist/PlaylistList.tsx
@@ -174,7 +174,7 @@ export default function PlaylistList() {
 	useKeyBinding(resolveKeybinding('CREATE_MIX'), startPlaylistRadio);
 	useKeyBinding(resolveKeybinding('CREATE_PLAYLIST'), handleCreate);
 	useKeyBinding(resolveKeybinding('DELETE_PLAYLIST'), handleDelete);
-	useKeyBinding(resolveKeybinding('BACK'), handleBack);
+	useKeyBinding(resolveKeybinding('BACK'), handleBack, {bypassBlock: true});
 	useKeyBinding(resolveKeybinding('DOWNLOAD'), () => {
 		void handleDownload();
 	});

--- a/source/components/plugins/PluginInstallDialog.tsx
+++ b/source/components/plugins/PluginInstallDialog.tsx
@@ -5,6 +5,7 @@ import TextInput from 'ink-text-input';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {usePlugins} from '../../stores/plugins.store.tsx';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 
 interface PluginInstallDialogProps {
@@ -51,7 +52,11 @@ export default function PluginInstallDialog({
 		}
 	}, [installing, onClose]);
 
-	useKeyBinding(resolveKeybinding('BACK'), handleClose);
+	// The URL input is focused: block global shortcuts while typing so the
+	// plugin name/URL can't trigger app actions. Escape still cancels via
+	// the bypass BACK handler.
+	useKeyboardBlocker(true);
+	useKeyBinding(resolveKeybinding('BACK'), handleClose, {bypassBlock: true});
 
 	return (
 		<Box flexDirection="column" gap={1}>

--- a/source/components/radio/RadioStationsList.tsx
+++ b/source/components/radio/RadioStationsList.tsx
@@ -341,7 +341,7 @@ export default function RadioStationsList() {
 	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
 	useKeyBinding(resolveKeybinding('SELECT'), playSelected);
 	useKeyBinding(resolveKeybinding('QUIT'), goBack);
-	useKeyBinding(resolveKeybinding('BACK'), goBack);
+	useKeyBinding(resolveKeybinding('BACK'), goBack, {bypassBlock: true});
 	useKeyBinding(resolveKeybinding('SEARCH'), startSearch);
 	useKeyBinding(['r'], () => {
 		void playRandom();

--- a/source/components/search/SearchBar.tsx
+++ b/source/components/search/SearchBar.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 import {SEARCH_TYPE} from '../../utils/constants.ts';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
-import {Box, Text, useInput} from 'ink';
+import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {Box, Text} from 'ink';
 import TextInput from 'ink-text-input';
 import {getConfigService} from '../../services/config/config.service.ts';
 
@@ -48,35 +49,13 @@ function SearchBar({onInput, isActive = true}: Props) {
 		[dispatch, onInput, isActive, config],
 	);
 
-	// Handle clearing search
-	const clearSearch = useCallback(() => {
-		if (isActive) {
-			setInput('');
-			onInput('');
-		}
-	}, [isActive, onInput]);
+	// Handle Tab to cycle search type via the central registry. This needs
+	// bypassBlock so it works while the text input is focused (blocked).
+	useKeyBinding(['tab'], cycleType, {bypassBlock: true});
 
-	// Handle Tab to cycle search type via direct useInput to avoid
-	// registry/keyboard-blocker interaction issues (GitHub #43)
-	useInput(
-		(_input, key) => {
-			if (key.tab && isActive) {
-				cycleType();
-			}
-		},
-		{isActive},
-	);
-
-	// Handle Escape to clear search via direct useInput
-	useInput(
-		(_input, key) => {
-			if (key.escape && isActive) {
-				clearSearch();
-			}
-		},
-		{isActive},
-	);
-
+	// Note: Escape is intentionally NOT handled here. While typing, Escape
+	// leaves the search view via SearchLayout's BACK handler (bypass), so Esc
+	// reliably means "back" instead of sometimes clearing, sometimes leaving.
 	useKeyboardBlocker(isActive);
 
 	return (

--- a/source/components/search/SearchHistory.tsx
+++ b/source/components/search/SearchHistory.tsx
@@ -38,6 +38,9 @@ export default function SearchHistory({onSelect}: Props) {
 	useKeyBinding(resolveKeybinding('UP'), navigateUp);
 	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
 	useKeyBinding(resolveKeybinding('SELECT'), handleSelect);
+	useKeyBinding(resolveKeybinding('BACK'), () => {
+		dispatch({category: 'GO_BACK'});
+	});
 
 	return (
 		<Box flexDirection="column" gap={1}>

--- a/source/components/settings/Settings.tsx
+++ b/source/components/settings/Settings.tsx
@@ -6,6 +6,7 @@ import {useTheme} from '../../hooks/useTheme.ts';
 import {useNavigation} from '../../hooks/useNavigation.ts';
 import {getConfigService} from '../../services/config/config.service.ts';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
+import {useKeyboardBlocker} from '../../hooks/useKeyboardBlocker.tsx';
 import {resolveKeybinding} from '../../utils/keybinding-resolver.ts';
 import {VIEW} from '../../utils/constants.ts';
 import {useSleepTimer} from '../../hooks/useSleepTimer.ts';
@@ -407,6 +408,32 @@ export default function Settings() {
 	useKeyBinding(resolveKeybinding('UP'), navigateUp);
 	useKeyBinding(resolveKeybinding('DOWN'), navigateDown);
 	useKeyBinding(resolveKeybinding('SELECT'), handleSelect);
+
+	// Block global shortcuts while editing a text field so typing doesn't
+	// trigger app actions (e.g. 'q' leaving settings mid-typing). The BACK
+	// handler below uses bypassBlock: Escape first cancels the edit, then
+	// leaves the view on the next press.
+	const isEditingText =
+		isEditingApiKey ||
+		isEditingDownloadDirectory ||
+		isEditingBaseUrl ||
+		isEditingCookiesFile;
+	useKeyboardBlocker(isEditingText);
+
+	useKeyBinding(
+		resolveKeybinding('BACK'),
+		() => {
+			if (isEditingText) {
+				setIsEditingApiKey(false);
+				setIsEditingDownloadDirectory(false);
+				setIsEditingBaseUrl(false);
+				setIsEditingCookiesFile(false);
+				return;
+			}
+			dispatch({category: 'GO_BACK'});
+		},
+		{bypassBlock: true},
+	);
 
 	const sleepTimerLabel =
 		isActive && remainingSeconds !== null

--- a/source/components/stats/StatsDashboard.tsx
+++ b/source/components/stats/StatsDashboard.tsx
@@ -1,5 +1,5 @@
-import {Box, Text, useInput} from 'ink';
-import {useState} from 'react';
+import {Box, Text} from 'ink';
+import {useState, useCallback} from 'react';
 import {useTheme} from '../../hooks/useTheme.ts';
 import {useStats} from '../../stores/stats.store.tsx';
 import {useKeyBinding} from '../../hooks/useKeyboard.ts';
@@ -25,33 +25,28 @@ export default function StatsDashboard() {
 		dispatch({category: 'GO_BACK'});
 	});
 
-	useInput((input, key) => {
-		if (key.ctrl || key.meta) {
-			return;
-		}
+	const shareToClipboard = useCallback(() => {
+		void (async () => {
+			const card = formatStatsShareCard(stats);
+			const copied = await copyTextToClipboard(card);
+			setStatus(
+				copied
+					? 'Share card copied to clipboard'
+					: 'Clipboard unavailable — press E to export to a file',
+			);
+		})();
+	}, [stats]);
 
-		const lower = input.toLowerCase();
-		if (lower === 's') {
-			void (async () => {
-				const card = formatStatsShareCard(stats);
-				const copied = await copyTextToClipboard(card);
-				setStatus(
-					copied
-						? 'Share card copied to clipboard'
-						: 'Clipboard unavailable — press E to export to a file',
-				);
-			})();
-			return;
-		}
+	const exportToFile = useCallback(() => {
+		void (async () => {
+			const card = formatStatsShareCard(stats);
+			const filePath = await writeStatsShareFile(card);
+			setStatus(`Exported share card to ${filePath}`);
+		})();
+	}, [stats]);
 
-		if (lower === 'e') {
-			void (async () => {
-				const card = formatStatsShareCard(stats);
-				const filePath = await writeStatsShareFile(card);
-				setStatus(`Exported share card to ${filePath}`);
-			})();
-		}
-	});
+	useKeyBinding(['s'], shareToClipboard);
+	useKeyBinding(['e'], exportToFile);
 
 	return (
 		<Box flexDirection="column" padding={1} gap={1}>

--- a/source/hooks/useKeyboard.ts
+++ b/source/hooks/useKeyboard.ts
@@ -11,8 +11,34 @@ type RegistryEntry = {
 	bypassBlock?: boolean;
 };
 
+// Minimal shape of Ink's key object needed for matching. Kept structural so
+// the matcher can be unit-tested without Ink.
+export type KeyInfo = {
+	ctrl?: boolean;
+	meta?: boolean;
+	shift?: boolean;
+	upArrow?: boolean;
+	downArrow?: boolean;
+	leftArrow?: boolean;
+	rightArrow?: boolean;
+	return?: boolean;
+	escape?: boolean;
+	backspace?: boolean;
+	delete?: boolean;
+	tab?: boolean;
+	pageUp?: boolean;
+	pageDown?: boolean;
+	home?: boolean;
+	end?: boolean;
+};
+
 // Global registry for key handlers
 const registry: Set<RegistryEntry> = new Set();
+
+/** Test-only: clear the global registry between tests. */
+export function resetKeyboardRegistryForTests(): void {
+	registry.clear();
+}
 
 // Callback to navigate to home (registered by MainLayout)
 let goHomeCallback: (() => void) | null = null;
@@ -34,10 +60,140 @@ export function setCurrentViewForCtrlC(view: string): void {
 	currentView = view;
 }
 
+/** True when the keypress represents Escape, including a raw ESC byte that
+ * some macOS terminals deliver without Ink setting key.escape. */
+export function isEscapeKey(input: string, key: KeyInfo): boolean {
+	return Boolean(key.escape) || input === '\x1b';
+}
+
+/**
+ * Match a single keybinding string (e.g. 'escape', 'ctrl+a', 'shift+right',
+ * '+', 'M') against an Ink keypress.
+ *
+ * Case convention: a single UPPERCASE letter binding (e.g. 'M') requires
+ * Shift (it matches Shift+m / 'M'); a lowercase letter binding explicitly
+ * does NOT match when Shift is held, so 'm' and 'M' are distinct bindings.
+ */
+export function matchKeyBinding(
+	binding: string,
+	input: string,
+	key: KeyInfo,
+): boolean {
+	const lowerBinding = binding.toLowerCase();
+
+	// A. Special keys (highest precedence). Skip Enter/Return when Ctrl is
+	// held so Ctrl+M (ASCII CR) can bind separately.
+	if (lowerBinding === 'escape' && isEscapeKey(input, key)) return true;
+	if (
+		(lowerBinding === 'return' || lowerBinding === 'enter') &&
+		key.return &&
+		!key.ctrl
+	)
+		return true;
+	if (lowerBinding === 'tab' && key.tab) return true;
+	if (lowerBinding === 'backspace' && (key.backspace || key.delete))
+		return true;
+	if (lowerBinding === 'delete' && (key.delete || key.backspace)) return true;
+	if (lowerBinding === 'up' && key.upArrow) return true;
+	if (lowerBinding === 'down' && key.downArrow) return true;
+	if (lowerBinding === 'left' && key.leftArrow) return true;
+	if (lowerBinding === 'right' && key.rightArrow) return true;
+	if (lowerBinding === 'pageup' && key.pageUp) return true;
+	if (lowerBinding === 'pagedown' && key.pageDown) return true;
+	if (lowerBinding === 'home' && key.home) return true;
+	if (lowerBinding === 'end' && key.end) return true;
+
+	// B. Combination and character keys
+	const parts = lowerBinding.split('+');
+	const hasCtrl = parts.includes('ctrl');
+	const hasMeta = parts.includes('meta') || parts.includes('alt');
+	const hasShift = parts.includes('shift');
+
+	// Robust main key detection (handles '+' correctly)
+	let mainKey = '';
+	if (lowerBinding === '+') {
+		mainKey = '+';
+	} else if (lowerBinding.endsWith('++')) {
+		mainKey = '+';
+	} else if (lowerBinding.endsWith('+') && parts.length > 1) {
+		mainKey = '+';
+	} else {
+		mainKey = parts[parts.length - 1]!;
+	}
+
+	if (hasCtrl && !key.ctrl) return false;
+	if (hasMeta && !key.meta) return false;
+
+	const isLetter = /^[a-z]$/.test(mainKey);
+	// A single uppercase letter binding (e.g. 'M') implies Shift.
+	const bindingImpliesShift =
+		binding.length === 1 &&
+		mainKey !== binding &&
+		binding === binding.toUpperCase() &&
+		isLetter;
+
+	if (hasShift || bindingImpliesShift) {
+		const shiftActive =
+			key.shift || (input.length === 1 && input !== input.toLowerCase());
+		if (!shiftActive) return false;
+	} else if (
+		isLetter &&
+		(key.shift || (input.length === 1 && input !== input.toLowerCase()))
+	) {
+		// Block 'p' if user typed 'P' (lowercase binding, Shift held)
+		return false;
+	}
+
+	// Arrow keys, optionally with modifiers (e.g. shift+right for seek)
+	if (mainKey === 'up' && key.upArrow) return true;
+	if (mainKey === 'down' && key.downArrow) return true;
+	if (mainKey === 'left' && key.leftArrow) return true;
+	if (mainKey === 'right' && key.rightArrow) return true;
+
+	// Ctrl+letter control codes (SOH–SUB)
+	if (hasCtrl && isLetter && input.length === 1) {
+		const charCode = input.charCodeAt(0);
+		if (charCode >= 1 && charCode <= 26) {
+			const derived = String.fromCharCode(charCode + 64);
+			if (derived.toLowerCase() === mainKey) return true;
+		}
+	}
+
+	// Ctrl+symbol (e.g. ctrl+,) when terminal reports key.ctrl
+	if (
+		hasCtrl &&
+		key.ctrl &&
+		input.length === 1 &&
+		input.toLowerCase() === mainKey
+	) {
+		return true;
+	}
+
+	// Symbol/char match
+	const inputLower = input.toLowerCase();
+	const isSymbolMatch =
+		(mainKey === '=' && input === '=') ||
+		(mainKey === '+' && input === '+') ||
+		(mainKey === '+' && key.shift && input === '=') ||
+		(mainKey === '-' && input === '-') ||
+		(mainKey === ']' && input === ']') ||
+		(mainKey === '[' && input === '[');
+
+	if (isSymbolMatch || (inputLower === mainKey && !key.ctrl && !key.meta)) {
+		return true;
+	}
+
+	return false;
+}
+
 /**
  * Hook to bind keyboard shortcuts.
  * This uses a centralized manager to avoid multiple useInput calls and memory leaks.
  * Uses a ref-based approach to always call the latest handler without stale closures.
+ *
+ * Dispatch is LIFO: the most recently registered handler for a key wins, so a
+ * focused child view overrides global bindings, and the global fallback in
+ * MainLayout only fires when nothing more specific handled the key.
  */
 export function useKeyBinding(
 	keys: readonly string[],
@@ -47,18 +203,28 @@ export function useKeyBinding(
 	const handlerRef = useRef(handler);
 	handlerRef.current = handler;
 
+	const bypassBlock = options?.bypassBlock ?? false;
+	// Serialize for the effect deps: inline arrays (e.g. ['M']) get a new
+	// identity every render, but equal content must not churn the registry.
+	const keysFingerprint = JSON.stringify([...keys]);
+
 	useEffect(() => {
+		// An empty key list disables the binding without occupying a slot.
+		if (keys.length === 0) {
+			return;
+		}
+
 		const entry: RegistryEntry = {
 			keys,
 			handler: () => handlerRef.current(),
-			bypassBlock: options?.bypassBlock,
+			bypassBlock,
 		};
 
 		// Log registration of volume down key for debugging
 		if (keys.includes('-') || keys.some(k => k.includes('-'))) {
 			logger.debug('KeyboardManager', 'Registered keybinding for "-"', {
 				keys,
-				bypassBlock: options?.bypassBlock,
+				bypassBlock,
 				stack: new Error().stack,
 			});
 		}
@@ -73,7 +239,15 @@ export function useKeyBinding(
 				});
 			}
 		};
-	}, [keys, options?.bypassBlock]); // keys and bypassBlock are deps; handlerRef is a stable ref
+		// keys is intentionally represented by keysFingerprint above: inline
+		// arrays get a new identity every render, but equal content must not
+		// churn the registry.
+	}, [keysFingerprint, bypassBlock]);
+}
+
+/** Snapshot of the registry in dispatch (LIFO) order. */
+function dispatchOrder(): RegistryEntry[] {
+	return [...registry].reverse();
 }
 
 /**
@@ -101,7 +275,7 @@ export function KeyboardManager() {
 			key.leftArrow ||
 			key.rightArrow ||
 			key.return ||
-			key.escape ||
+			isEscapeKey(input, key) ||
 			key.backspace ||
 			key.delete ||
 			key.tab ||
@@ -137,100 +311,41 @@ export function KeyboardManager() {
 				process.exit(0);
 			}
 
-			for (const entry of registry) {
-				if (entry.bypassBlock) {
-					for (const binding of entry.keys) {
-						const lowerBinding = binding.toLowerCase();
+			// Escape always bypasses the block so users can leave/close text
+			// inputs with the same key everywhere (macOS reliability: this
+			// covers both key.escape and a raw ESC byte).
+			const pressedEscape = isEscapeKey(input, key);
 
-						// Check for ESC key (most common bypass case)
-						if (lowerBinding === 'escape' && key.escape) {
-							entry.handler();
-							return;
-						}
+			for (const entry of dispatchOrder()) {
+				// Non-bypass entries stay silent while blocked, except for
+				// Escape which is always allowed through.
+				if (!entry.bypassBlock && !pressedEscape) {
+					continue;
+				}
 
-						// Handle other bypass keys
-						const isMatch =
-							((lowerBinding === 'return' || lowerBinding === 'enter') &&
-								key.return) ||
-							(lowerBinding === 'backspace' && key.backspace) ||
-							(lowerBinding === 'tab' && key.tab) ||
-							(lowerBinding === 'up' && key.upArrow) ||
-							(lowerBinding === 'down' && key.downArrow) ||
-							(lowerBinding === 'left' && key.leftArrow) ||
-							(lowerBinding === 'right' && key.rightArrow) ||
-							(lowerBinding === 'pageup' && key.pageUp) ||
-							(lowerBinding === 'pagedown' && key.pageDown) ||
-							(() => {
-								const parts = lowerBinding.split('+');
-								const hasCtrl = parts.includes('ctrl');
-								const hasMeta = parts.includes('meta') || parts.includes('alt');
-								const hasShift = parts.includes('shift');
-
-								// Robust main key detection (handles '+' correctly)
-								let mainKey = '';
-								if (lowerBinding === '+') {
-									mainKey = '+';
-								} else if (lowerBinding.endsWith('++')) {
-									mainKey = '+';
-								} else if (lowerBinding.endsWith('+') && parts.length > 1) {
-									mainKey = '+';
-								} else {
-									mainKey = parts[parts.length - 1]!;
-								}
-
-								if (hasCtrl && !key.ctrl) return false;
-								if (hasMeta && !key.meta) return false;
-								if (hasShift && !key.shift) return false;
-
-								// Check arrow keys
-								if (mainKey === 'up' && key.upArrow) return true;
-								if (mainKey === 'down' && key.downArrow) return true;
-								if (mainKey === 'left' && key.leftArrow) return true;
-								if (mainKey === 'right' && key.rightArrow) return true;
-
-								// Handle '=' and '+'
-								if (mainKey === '=' && input === '=') return true;
-								if (mainKey === '+' && input === '+') return true;
-								if (mainKey === '+' && key.shift && input === '=') return true;
-
-								// Ctrl+letter control codes (SOH–SUB)
-								if (hasCtrl && /^[a-z]$/.test(mainKey) && input.length === 1) {
-									const charCode = input.charCodeAt(0);
-									if (charCode >= 1 && charCode <= 26) {
-										const derived = String.fromCharCode(charCode + 64);
-										if (derived.toLowerCase() === mainKey) return true;
-									}
-								}
-
-								// Ctrl+symbol (e.g. ctrl+,) when terminal reports key.ctrl
-								if (
-									hasCtrl &&
-									key.ctrl &&
-									input.length === 1 &&
-									input.toLowerCase() === mainKey
-								) {
-									return true;
-								}
-
-								return (
-									input.toLowerCase() === mainKey && !key.ctrl && !key.meta
-								);
-							})();
-
-						if (isMatch) {
-							logger.debug(
-								'KeyboardManager',
-								'Bypass block: handler triggered',
-								{
-									binding,
-									input,
-									key: {ctrl: key.ctrl, shift: key.shift, meta: key.meta},
-								},
-							);
-							entry.handler();
-							return;
-						}
+				for (const binding of entry.keys) {
+					if (!matchKeyBinding(binding, input, key)) {
+						continue;
 					}
+
+					// A non-bypass entry only fires while blocked when the
+					// pressed key itself is Escape; other matches on that
+					// entry must wait until the input is no longer focused.
+					if (
+						!entry.bypassBlock &&
+						binding.toLowerCase() !== 'escape' &&
+						pressedEscape
+					) {
+						continue;
+					}
+
+					logger.debug('KeyboardManager', 'Bypass block: handler triggered', {
+						binding,
+						input,
+						key: {ctrl: key.ctrl, shift: key.shift, meta: key.meta},
+					});
+					entry.handler();
+					return;
 				}
 			}
 			return;
@@ -253,127 +368,33 @@ export function KeyboardManager() {
 			});
 		}
 
-		// Dispatch to registered handlers
-		for (const entry of registry) {
+		// Dispatch to registered handlers (LIFO: focused view wins)
+		for (const entry of dispatchOrder()) {
 			const {keys, handler} = entry;
 
 			for (const binding of keys) {
-				const lowerBinding = binding.toLowerCase();
-
-				// A. Match Special Keys (Highest precedence)
-				// Skip Enter/Return when Ctrl is held so Ctrl+M (ASCII CR) can bind separately.
-				const isSpecialMatch =
-					(lowerBinding === 'up' && key.upArrow) ||
-					(lowerBinding === 'down' && key.downArrow) ||
-					(lowerBinding === 'left' && key.leftArrow) ||
-					(lowerBinding === 'right' && key.rightArrow) ||
-					(lowerBinding === 'escape' && key.escape) ||
-					(lowerBinding === 'return' && key.return && !key.ctrl) ||
-					(lowerBinding === 'enter' && key.return && !key.ctrl) ||
-					(lowerBinding === 'tab' && key.tab) ||
-					(lowerBinding === 'backspace' && key.backspace) ||
-					(lowerBinding === 'pageup' && key.pageUp) ||
-					(lowerBinding === 'pagedown' && key.pageDown);
-
-				if (isSpecialMatch) {
-					handler();
-					return; // STOP: prevent double-dispatch
-				}
-
-				// B. Match Combination and Character keys
-				const parts = lowerBinding.split('+');
-				const hasCtrl = parts.includes('ctrl');
-				const hasMeta = parts.includes('meta') || parts.includes('alt');
-				const hasShift = parts.includes('shift');
-
-				// Robust main key detection (handles '+')
-				let mainKey = '';
-				if (lowerBinding === '+') {
-					mainKey = '+';
-				} else if (lowerBinding.endsWith('++')) {
-					mainKey = '+';
-				} else if (lowerBinding.endsWith('+') && parts.length > 1) {
-					mainKey = '+';
-				} else {
-					mainKey = parts[parts.length - 1]!;
-				}
-
-				// Check modifiers
-				if (hasCtrl && !key.ctrl) continue;
-				if (hasMeta && !key.meta) continue;
-
-				// Shift handling: block lowercase letter bindings when shift is active,
-				// but allow symbol keys like '+' or '=' to work regardless.
-				const isLetter = /^[a-z]$/.test(mainKey);
-				if (hasShift) {
-					const uppercaseMatch =
-						input.length === 1 &&
-						input === input.toUpperCase() &&
-						input.toLowerCase() === mainKey;
-					if (!key.shift && !uppercaseMatch) continue;
-				} else if (
-					isLetter &&
-					(key.shift || (input.length === 1 && input !== input.toLowerCase()))
-				) {
-					// Block 'p' if user typed 'P'
+				if (!matchKeyBinding(binding, input, key)) {
 					continue;
 				}
 
-				// Handle Ctrl+letter (control characters)
-				if (hasCtrl && isLetter && input.length === 1) {
-					const charCode = input.charCodeAt(0);
-					// Control codes for A-Z are 1-26 (SOH to Z)
-					if (charCode >= 1 && charCode <= 26) {
-						const derived = String.fromCharCode(charCode + 64); // 'A'-'Z'
-						if (derived.toLowerCase() === mainKey) {
-							handler();
-							return;
-						}
-					}
+				// Enhanced logging for volume keys
+				const mainKey =
+					binding.toLowerCase() === '+'
+						? '+'
+						: binding.toLowerCase().split('+').pop();
+				if (mainKey === '-' || mainKey === '+' || mainKey === '=') {
+					logger.debug('KeyboardManager', 'Volume key handler triggered', {
+						binding,
+						mainKey,
+						input,
+						keyShifts: {ctrl: key.ctrl, meta: key.meta, shift: key.shift},
+						stack: new Error().stack,
+						registrySize: registry.size,
+					});
 				}
 
-				// Ctrl+non-letter (e.g. ctrl+,) when terminal reports modifiers + symbol
-				if (
-					hasCtrl &&
-					!isLetter &&
-					key.ctrl &&
-					input.length === 1 &&
-					input.toLowerCase() === mainKey
-				) {
-					handler();
-					return;
-				}
-
-				// Check for symbol/char match
-				const inputLower = input.toLowerCase();
-				const isSymbolMatch =
-					(mainKey === '=' && input === '=') ||
-					(mainKey === '+' && input === '+') ||
-					(mainKey === '+' && key.shift && input === '=') ||
-					(mainKey === '-' && input === '-') ||
-					(mainKey === ']' && input === ']') ||
-					(mainKey === '[' && input === '[');
-
-				if (
-					isSymbolMatch ||
-					(inputLower === mainKey && !key.ctrl && !key.meta)
-				) {
-					// Enhanced logging for volume keys
-					if (mainKey === '-' || mainKey === '+' || mainKey === '=') {
-						logger.debug('KeyboardManager', 'Volume key handler triggered', {
-							binding,
-							mainKey,
-							input,
-							keyShifts: {ctrl: key.ctrl, meta: key.meta, shift: key.shift},
-							isSymbolMatch,
-							stack: new Error().stack,
-							registrySize: registry.size,
-						});
-					}
-
-					handler();
-					return; // STOP: prevent double-dispatch
-				}
+				handler();
+				return; // STOP: prevent double-dispatch
 			}
 		}
 	});

--- a/source/stores/navigation.store.tsx
+++ b/source/stores/navigation.store.tsx
@@ -21,7 +21,7 @@ const defaultSearchFilters: SearchFilters = {
 	duration: 'all',
 };
 
-const initialState: NavigationState = {
+export const initialState: NavigationState = {
 	currentView: VIEW.HOME,
 	previousView: null,
 	searchQuery: '',
@@ -36,12 +36,20 @@ const initialState: NavigationState = {
 	searchFilters: defaultSearchFilters,
 };
 
-function navigationReducer(
+export function navigationReducer(
 	state: NavigationState,
 	action: NavigationAction,
 ): NavigationState {
 	switch (action.category) {
 		case 'NAVIGATE':
+			// Navigating to the view we're already in is a no-op. Without
+			// this guard, repeat presses of a view's own shortcut (e.g. 'e'
+			// while in Explore, '/' while in Search) stack duplicate entries
+			// onto history, and a later GO_BACK pops back to the same view —
+			// making Escape appear to do nothing.
+			if (action.view === state.currentView) {
+				return state;
+			}
 			return {
 				...state,
 				currentView: action.view,
@@ -51,7 +59,18 @@ function navigationReducer(
 
 		case 'GO_BACK':
 			if (state.history.length === 0) {
-				return state;
+				// Nowhere to go back to: fall back to home (unless already
+				// there) so Escape always produces a visible result instead
+				// of silently doing nothing.
+				if (state.currentView === VIEW.HOME) {
+					return state;
+				}
+				return {
+					...state,
+					currentView: VIEW.HOME,
+					previousView: state.currentView,
+					history: [],
+				};
 			}
 			const previousViews = [...state.history];
 			const backView = previousViews.pop()!;

--- a/tests/keyboard-matcher.test.js
+++ b/tests/keyboard-matcher.test.js
@@ -1,0 +1,66 @@
+import {expect, test} from 'bun:test';
+import {
+	matchKeyBinding,
+	isEscapeKey,
+	resetKeyboardRegistryForTests,
+} from '../source/hooks/useKeyboard.ts';
+
+test('isEscapeKey covers Ink flag and raw ESC byte (macOS terminals)', () => {
+	expect(isEscapeKey('', {escape: true})).toBe(true);
+	expect(isEscapeKey('\x1b', {})).toBe(true);
+	expect(isEscapeKey('a', {})).toBe(false);
+	expect(isEscapeKey('', {})).toBe(false);
+});
+
+test('escape binding matches both Ink flag and raw byte', () => {
+	expect(matchKeyBinding('escape', '', {escape: true})).toBe(true);
+	expect(matchKeyBinding('escape', '\x1b', {})).toBe(true);
+	expect(matchKeyBinding('escape', 'a', {})).toBe(false);
+});
+
+test('uppercase single-letter binding requires Shift (M vs m)', () => {
+	// Shift+M matches 'M'
+	expect(matchKeyBinding('M', 'M', {shift: true})).toBe(true);
+	// lowercase m must NOT trigger the 'M' binding ...
+	expect(matchKeyBinding('M', 'm', {})).toBe(false);
+	// ... and uppercase M must NOT trigger the lowercase 'm' binding
+	expect(matchKeyBinding('m', 'M', {shift: true})).toBe(false);
+	expect(matchKeyBinding('m', 'm', {})).toBe(true);
+});
+
+test('ctrl+letter matches control codes', () => {
+	// Ctrl+A arrives as SOH (0x01) with ctrl flag
+	expect(matchKeyBinding('ctrl+a', '', {ctrl: true})).toBe(true);
+	expect(matchKeyBinding('ctrl+a', 'a', {})).toBe(false);
+});
+
+test('volume symbols match', () => {
+	expect(matchKeyBinding('=', '=', {})).toBe(true);
+	expect(matchKeyBinding('+', '+', {})).toBe(true);
+	expect(matchKeyBinding('-', '-', {})).toBe(true);
+	// Shift+= produces '+' on many layouts
+	expect(matchKeyBinding('+', '=', {shift: true})).toBe(true);
+});
+
+test('return does not match when Ctrl is held (Ctrl+M separation)', () => {
+	expect(matchKeyBinding('return', '\r', {return: true})).toBe(true);
+	expect(matchKeyBinding('enter', '\r', {return: true})).toBe(true);
+	expect(matchKeyBinding('return', '', {return: true, ctrl: true})).toBe(false);
+});
+
+test('delete binding matches delete or backspace', () => {
+	expect(matchKeyBinding('delete', '', {delete: true})).toBe(true);
+	expect(matchKeyBinding('backspace', '', {backspace: true})).toBe(true);
+});
+
+test('shift+arrow combos match', () => {
+	expect(
+		matchKeyBinding('shift+right', '', {shift: true, rightArrow: true}),
+	).toBe(true);
+	expect(matchKeyBinding('shift+right', '', {rightArrow: true})).toBe(false);
+});
+
+test('registry reset helper exists for test isolation', () => {
+	resetKeyboardRegistryForTests();
+	expect(true).toBe(true);
+});

--- a/tests/navigation-back.test.js
+++ b/tests/navigation-back.test.js
@@ -1,0 +1,52 @@
+import {expect, test} from 'bun:test';
+import {
+	navigationReducer,
+	initialState,
+} from '../source/stores/navigation.store.tsx';
+import {VIEW} from '../source/utils/constants.ts';
+
+test('NAVIGATE to the current view is a no-op (no history spam)', () => {
+	const state = {
+		...initialState,
+		currentView: VIEW.EXPLORE,
+		history: [VIEW.HOME],
+	};
+	const next = navigationReducer(state, {
+		category: 'NAVIGATE',
+		view: VIEW.EXPLORE,
+	});
+	expect(next).toEqual(state);
+	expect(next.history).toEqual([VIEW.HOME]);
+});
+
+test('NAVIGATE to a new view pushes history', () => {
+	const next = navigationReducer(initialState, {
+		category: 'NAVIGATE',
+		view: VIEW.SEARCH,
+	});
+	expect(next.currentView).toBe(VIEW.SEARCH);
+	expect(next.history).toEqual([VIEW.HOME]);
+});
+
+test('GO_BACK pops history', () => {
+	const state = {
+		...initialState,
+		currentView: VIEW.SEARCH,
+		previousView: VIEW.HOME,
+		history: [VIEW.HOME],
+	};
+	const next = navigationReducer(state, {category: 'GO_BACK'});
+	expect(next.currentView).toBe(VIEW.HOME);
+	expect(next.history).toEqual([]);
+});
+
+test('GO_BACK with empty history falls back to home', () => {
+	const state = {...initialState, currentView: VIEW.SEARCH, history: []};
+	const next = navigationReducer(state, {category: 'GO_BACK'});
+	expect(next.currentView).toBe(VIEW.HOME);
+});
+
+test('GO_BACK with empty history on home is a no-op', () => {
+	const next = navigationReducer(initialState, {category: 'GO_BACK'});
+	expect(next).toEqual(initialState);
+});


### PR DESCRIPTION
## Problem

Escape to go back often did nothing, and several controls misbehaved:

- A global Back handler swallowed Escape in every view except player, so per-view Back handlers never fired.
- Repeat presses of a view's own shortcut (e.g. `e` in Explore, `/` in Search) stacked duplicate history entries, so going back popped to the same view.
- Uppercase single-letter bindings (`M`, `T`) matched lowercase input, colliding with Genres (`Shift+M`) and mix (`m`).
- PlayerControls arrows raced list navigation in Favorites/Radio/Live views.
- Several text inputs had no keyboard blocker, so typing fired app shortcuts (e.g. `q` leaving AI chat mid-typing).
- Some views advertised `Esc to go back` (Lyrics, Plugins, Settings, Favorites, Suggestions, SearchHistory, AI chat) but had no Back binding.

## Changes

- `source/hooks/useKeyboard.ts`: LIFO dispatch (focused view wins, global Back is a fallback), raw ESC byte matching, Shift required for uppercase single-letter bindings, churn-free registration, Escape always bypasses the input block.
- `source/stores/navigation.store.tsx`: same-view `NAVIGATE` is a no-op; empty-history `GO_BACK` falls back to Home.
- `MainLayout`: global Back fallback (exits mini-player first when active); mini-player toggle moved `M` -> `v` to resolve the `Shift+M` collision with Genres.
- `PlayerControls`: arrows only bound in the player view.
- Trending/Explore/Genres/NewReleases/Stats/SearchBar/Keybindings capture all routed through the central registry (no more competing `useInput` handlers).
- Search Escape is staged: filter -> results -> leave.
- Added missing Back bindings and input blockers; removed the dead `stdin.on('keypress')` hack in Import.
- New regression tests: `tests/keyboard-matcher.test.js`, `tests/navigation-back.test.js`.

## Verification

- `bun test`: 232 pass, 0 fail
- `bun run typecheck`: clean
- eslint and prettier: clean

## Manual smoke test

```bash
bun run --bun source/cli.tsx
```

Try: `/` search -> type -> `Esc`; `Esc` in Favorites/Settings/Lyrics/Plugins/AI chat; `Shift+M` (Genres only) and `v` (mini-player); `↑/↓` in Favorites; typing `q` in AI chat / import URL.

## Summary by Sourcery

Make keyboard navigation and Escape/back behavior reliable throughout the application.

New Features:
- Provide reliable Escape/back navigation across views, including staged back behavior in Search and fallback navigation to Home.
- Support distinct shifted uppercase shortcuts and move mini-player toggling to `v`.
- Block global shortcuts while users type or capture keybindings while keeping Escape available for navigation or cancellation.

Bug Fixes:
- Prevent duplicate history entries when navigating repeatedly to the current view.
- Ensure focused view handlers take priority over global handlers and prevent player arrows from conflicting with list navigation.
- Handle Escape consistently across terminals, including raw ESC input, and add missing Back actions to views that advertise them.

Enhancements:
- Route view controls through the centralized keyboard registry with stable registration and LIFO dispatch.
- Remove competing direct input handlers and the obsolete Import keypress workaround.

Documentation:
- Update keyboard shortcut documentation and in-app help for staged Search Escape behavior and the mini-player shortcut.

Tests:
- Add regression coverage for keyboard matching, modifier handling, raw Escape input, and navigation history behavior.