### PR TITLE
fix: guide users when YouTube streams fail to load

### DIFF
--- a/source/immersive/immersive-app.ts
+++ b/source/immersive/immersive-app.ts
@@ -438,7 +438,9 @@ export async function startImmersiveApp(
 			state.isPlaying = false;
 			clearAdvanceGrace();
 			playerService.stop();
-			const message = formatPlaybackErrorMessage(error);
+			const message = formatPlaybackErrorMessage(error, {
+				knownYouTubeSource: resolved.source === 'youtube',
+			});
 			showTrackChangeToast('Playback error', message);
 		} finally {
 			isAdvancing = false;

--- a/source/services/player/dependency-check.service.ts
+++ b/source/services/player/dependency-check.service.ts
@@ -88,13 +88,28 @@ export function isYtDlpVersionStale(
 function captureStdout(
 	command: string,
 	args: string[],
+	timeoutMs = 10_000,
 ): Promise<string | null> {
 	return new Promise(resolve => {
 		const child = spawn(command, args, {stdio: ['ignore', 'pipe', 'ignore']});
 		let output = '';
+		let settled = false;
+		const settle = (value: string | null) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve(value);
+		};
+
+		// Never let a hung executable stall startup: kill and give up.
+		const timer = setTimeout(() => {
+			child.kill('SIGKILL');
+			settle(null);
+		}, timeoutMs);
+		timer.unref?.();
 
 		child.once('error', () => {
-			resolve(null);
+			settle(null);
 		});
 
 		child.stdout?.on('data', (chunk: Buffer) => {
@@ -102,7 +117,7 @@ function captureStdout(
 		});
 
 		child.once('close', code => {
-			resolve(code === 0 ? output : null);
+			settle(code === 0 ? output : null);
 		});
 	});
 }
@@ -117,7 +132,7 @@ async function warnIfYtDlpStale(): Promise<void> {
 
 		console.error(
 			`Warning: yt-dlp ${output.trim()} is over ${YTDLP_STALE_AFTER_DAYS} days old. ` +
-				'YouTube frequently breaks older versions — update with: brew upgrade yt-dlp (or yt-dlp -U).\n',
+				'YouTube frequently breaks older versions — update with: yt-dlp -U (or brew upgrade yt-dlp).\n',
 		);
 	} catch {
 		// Freshness is best-effort; never block playback on it.

--- a/source/services/player/dependency-check.service.ts
+++ b/source/services/player/dependency-check.service.ts
@@ -46,6 +46,84 @@ async function commandExists(command: string): Promise<boolean> {
 	return runCommand(command, ['--version'], {stdio: 'ignore'});
 }
 
+/** Warn when yt-dlp is older than this: YouTube breaks old versions often. */
+export const YTDLP_STALE_AFTER_DAYS = 45;
+
+/** Parse `yt-dlp --version` output (YYYY.MM.DD) into a Date, or null. */
+export function parseYtDlpVersionDate(output: string): Date | null {
+	const match = output.trim().match(/^(\d{4})\.(\d{2})\.(\d{2})/);
+	if (!match?.[1] || !match?.[2] || !match?.[3]) {
+		return null;
+	}
+
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const date = new Date(Date.UTC(year, month - 1, day));
+	if (
+		date.getUTCFullYear() !== year ||
+		date.getUTCMonth() !== month - 1 ||
+		date.getUTCDate() !== day
+	) {
+		return null;
+	}
+
+	return date;
+}
+
+export function isYtDlpVersionStale(
+	versionOutput: string,
+	now: Date = new Date(),
+	staleAfterDays: number = YTDLP_STALE_AFTER_DAYS,
+): boolean {
+	const released = parseYtDlpVersionDate(versionOutput);
+	if (!released) {
+		return false;
+	}
+
+	const ageMs = now.getTime() - released.getTime();
+	return ageMs > staleAfterDays * 24 * 60 * 60 * 1000;
+}
+
+function captureStdout(
+	command: string,
+	args: string[],
+): Promise<string | null> {
+	return new Promise(resolve => {
+		const child = spawn(command, args, {stdio: ['ignore', 'pipe', 'ignore']});
+		let output = '';
+
+		child.once('error', () => {
+			resolve(null);
+		});
+
+		child.stdout?.on('data', (chunk: Buffer) => {
+			output += chunk.toString();
+		});
+
+		child.once('close', code => {
+			resolve(code === 0 ? output : null);
+		});
+	});
+}
+
+/** Non-fatal freshness nudge: stale yt-dlp is the #1 cause of sudden 403s. */
+async function warnIfYtDlpStale(): Promise<void> {
+	try {
+		const output = await captureStdout('yt-dlp', ['--version']);
+		if (!output || !isYtDlpVersionStale(output)) {
+			return;
+		}
+
+		console.error(
+			`Warning: yt-dlp ${output.trim()} is over ${YTDLP_STALE_AFTER_DAYS} days old. ` +
+				'YouTube frequently breaks older versions — update with: brew upgrade yt-dlp (or yt-dlp -U).\n',
+		);
+	} catch {
+		// Freshness is best-effort; never block playback on it.
+	}
+}
+
 async function getMissingDependencies(): Promise<PlaybackDependency[]> {
 	const missing: PlaybackDependency[] = [];
 	for (const dependency of REQUIRED_DEPENDENCIES) {
@@ -156,6 +234,7 @@ export async function ensurePlaybackDependencies(options: {
 }): Promise<{ready: boolean; missing: PlaybackDependency[]}> {
 	const missing = await getMissingDependencies();
 	if (missing.length === 0) {
+		await warnIfYtDlpStale();
 		return {ready: true, missing: []};
 	}
 

--- a/source/services/player/ytdl-cookies.ts
+++ b/source/services/player/ytdl-cookies.ts
@@ -8,6 +8,9 @@ export type CookieOptions = {
 export const COOKIES_BOT_HINT =
 	'YouTube blocked playback (bot check). In Settings, set Cookies From Browser (e.g. Edge) or Cookies File, then retry.';
 
+export const YTDLP_STALE_HINT =
+	'YouTube refused to load this stream (HTTP 403). Update yt-dlp (e.g. brew upgrade yt-dlp, or yt-dlp -U) and retry. If it persists, set Cookies From Browser or Cookies File in Settings, then retry.';
+
 export function resolveCookieOptions(options: CookieOptions): CookieOptions {
 	const file = options.cookiesFile?.trim();
 	if (file) {
@@ -64,10 +67,32 @@ export function isYouTubeBotCheckError(message: string): boolean {
 	);
 }
 
+/**
+ * Detect a YouTube stream load failure: extraction succeeded but the media
+ * URL was rejected (HTTP 403 from googlevideo), or mpv died right at load
+ * (exit code 2 = error playing file). Seen with stale yt-dlp versions and
+ * on bot-flagged networks; both cases share the same remediation.
+ */
+export function isYouTubeLoadFailure(message: string): boolean {
+	const lower = message.toLowerCase();
+	return (
+		lower.includes('403') ||
+		lower.includes('forbidden') ||
+		lower.includes('failed to open') ||
+		lower.includes('errors when loading file') ||
+		lower.includes('mpv exited with code 2') ||
+		lower.includes('mpv exited with code 3')
+	);
+}
+
 export function formatPlaybackErrorMessage(error: unknown): string {
 	const message = error instanceof Error ? error.message : String(error);
 	if (isYouTubeBotCheckError(message)) {
 		return COOKIES_BOT_HINT;
+	}
+
+	if (isYouTubeLoadFailure(message)) {
+		return YTDLP_STALE_HINT;
 	}
 
 	return message;

--- a/source/services/player/ytdl-cookies.ts
+++ b/source/services/player/ytdl-cookies.ts
@@ -9,7 +9,7 @@ export const COOKIES_BOT_HINT =
 	'YouTube blocked playback (bot check). In Settings, set Cookies From Browser (e.g. Edge) or Cookies File, then retry.';
 
 export const YTDLP_STALE_HINT =
-	'YouTube refused to load this stream (HTTP 403). Update yt-dlp (e.g. brew upgrade yt-dlp, or yt-dlp -U) and retry. If it persists, set Cookies From Browser or Cookies File in Settings, then retry.';
+	'YouTube refused to load this stream (HTTP 403). Update yt-dlp (yt-dlp -U, or brew upgrade yt-dlp) and retry. If it persists, set Cookies From Browser or Cookies File in Settings, then retry.';
 
 export function resolveCookieOptions(options: CookieOptions): CookieOptions {
 	const file = options.cookiesFile?.trim();
@@ -70,28 +70,51 @@ export function isYouTubeBotCheckError(message: string): boolean {
 /**
  * Detect a YouTube stream load failure: extraction succeeded but the media
  * URL was rejected (HTTP 403 from googlevideo), or mpv died right at load
- * (exit code 2 = error playing file). Seen with stale yt-dlp versions and
+ * (exit code 2/3 = error playing file). Seen with stale yt-dlp versions and
  * on bot-flagged networks; both cases share the same remediation.
+ *
+ * Generic mpv strings (exit codes, "failed to open") also occur for local
+ * files and radio streams, so they only map when the message carries
+ * YouTube evidence or the caller confirms a YouTube source — otherwise the
+ * original diagnostic is preserved.
  */
-export function isYouTubeLoadFailure(message: string): boolean {
+export function isYouTubeLoadFailure(
+	message: string,
+	options?: {knownYouTubeSource?: boolean},
+): boolean {
 	const lower = message.toLowerCase();
-	return (
+	const matches =
 		lower.includes('403') ||
 		lower.includes('forbidden') ||
 		lower.includes('failed to open') ||
 		lower.includes('errors when loading file') ||
 		lower.includes('mpv exited with code 2') ||
-		lower.includes('mpv exited with code 3')
+		lower.includes('mpv exited with code 3');
+	if (!matches) {
+		return false;
+	}
+
+	if (options?.knownYouTubeSource) {
+		return true;
+	}
+
+	return (
+		lower.includes('youtube') ||
+		lower.includes('googlevideo') ||
+		lower.includes('watch?v=')
 	);
 }
 
-export function formatPlaybackErrorMessage(error: unknown): string {
+export function formatPlaybackErrorMessage(
+	error: unknown,
+	options?: {knownYouTubeSource?: boolean},
+): string {
 	const message = error instanceof Error ? error.message : String(error);
 	if (isYouTubeBotCheckError(message)) {
 		return COOKIES_BOT_HINT;
 	}
 
-	if (isYouTubeLoadFailure(message)) {
+	if (isYouTubeLoadFailure(message, options)) {
 		return YTDLP_STALE_HINT;
 	}
 

--- a/source/stores/player.store.tsx
+++ b/source/stores/player.store.tsx
@@ -927,7 +927,9 @@ function PlayerManager() {
 							);
 							dispatch({
 								category: 'SET_ERROR',
-								error: formatPlaybackErrorMessage(error),
+								error: formatPlaybackErrorMessage(error, {
+									knownYouTubeSource: resolved.source === 'youtube',
+								}),
 							});
 							return;
 						}
@@ -944,7 +946,9 @@ function PlayerManager() {
 						loadingStartedAtRef.current = 0;
 						dispatch({
 							category: 'SET_ERROR',
-							error: `${formatPlaybackErrorMessage(error)} (after ${MAX_RETRIES} attempts)`,
+							error: `${formatPlaybackErrorMessage(error, {
+								knownYouTubeSource: resolved.source === 'youtube',
+							})} (after ${MAX_RETRIES} attempts)`,
 						});
 					}
 				}

--- a/tests/stream-error-hint.test.js
+++ b/tests/stream-error-hint.test.js
@@ -1,0 +1,61 @@
+import {expect, test} from 'bun:test';
+import {
+	formatPlaybackErrorMessage,
+	isYouTubeBotCheckError,
+	isYouTubeLoadFailure,
+	YTDLP_STALE_HINT,
+	COOKIES_BOT_HINT,
+} from '../source/services/player/ytdl-cookies.ts';
+import {
+	isYtDlpVersionStale,
+	parseYtDlpVersionDate,
+} from '../source/services/player/dependency-check.service.ts';
+
+test('bot check errors map to the cookies hint', () => {
+	expect(isYouTubeBotCheckError('Sign in to confirm you are not a bot')).toBe(
+		true,
+	);
+	expect(formatPlaybackErrorMessage(new Error('Sign in to confirm'))).toBe(
+		COOKIES_BOT_HINT,
+	);
+});
+
+test('googlevideo 403 maps to the update-yt-dlp hint', () => {
+	expect(
+		isYouTubeLoadFailure(
+			'Failed to open https://rr1---sn-xxx.googlevideo.com/videoplayback?x=1: HTTP error 403 Forbidden',
+		),
+	).toBe(true);
+	expect(isYouTubeLoadFailure('mpv exited with code 2')).toBe(true);
+	expect(formatPlaybackErrorMessage(new Error('mpv exited with code 2'))).toBe(
+		YTDLP_STALE_HINT,
+	);
+});
+
+test('unrelated errors pass through unchanged', () => {
+	expect(isYouTubeLoadFailure('IPC connection failed: timeout')).toBe(false);
+	expect(formatPlaybackErrorMessage(new Error('boom'))).toBe('boom');
+});
+
+test('bot check takes precedence over load failure', () => {
+	expect(
+		formatPlaybackErrorMessage(
+			new Error('403 Sign in to confirm you are not a bot'),
+		),
+	).toBe(COOKIES_BOT_HINT);
+});
+
+test('yt-dlp version date parsing', () => {
+	expect(parseYtDlpVersionDate('2026.08.19\n')?.toISOString()).toBe(
+		'2026-08-19T00:00:00.000Z',
+	);
+	expect(parseYtDlpVersionDate('nightly')).toBe(null);
+	expect(parseYtDlpVersionDate('2026.13.99')).toBe(null);
+});
+
+test('yt-dlp staleness threshold', () => {
+	const now = new Date('2026-09-08T00:00:00.000Z');
+	expect(isYtDlpVersionStale('2026.08.19', now)).toBe(false);
+	expect(isYtDlpVersionStale('2026.07.04', now)).toBe(true);
+	expect(isYtDlpVersionStale('garbage', now)).toBe(false);
+});

--- a/tests/stream-error-hint.test.js
+++ b/tests/stream-error-hint.test.js
@@ -26,10 +26,32 @@ test('googlevideo 403 maps to the update-yt-dlp hint', () => {
 			'Failed to open https://rr1---sn-xxx.googlevideo.com/videoplayback?x=1: HTTP error 403 Forbidden',
 		),
 	).toBe(true);
-	expect(isYouTubeLoadFailure('mpv exited with code 2')).toBe(true);
+	expect(
+		formatPlaybackErrorMessage(
+			new Error(
+				'Failed to open https://rr1---sn-xxx.googlevideo.com/videoplayback?x=1: 403',
+			),
+		),
+	).toBe(YTDLP_STALE_HINT);
+});
+
+test('bare mpv exit codes need YouTube evidence or a known source', () => {
+	// No evidence: original diagnostic preserved (e.g. local files, radio).
+	expect(isYouTubeLoadFailure('mpv exited with code 2')).toBe(false);
 	expect(formatPlaybackErrorMessage(new Error('mpv exited with code 2'))).toBe(
-		YTDLP_STALE_HINT,
+		'mpv exited with code 2',
 	);
+	// Known YouTube source (e.g. empty stderr after --really-quiet): hinted.
+	expect(
+		isYouTubeLoadFailure('mpv exited with code 2', {
+			knownYouTubeSource: true,
+		}),
+	).toBe(true);
+	expect(
+		formatPlaybackErrorMessage(new Error('mpv exited with code 2'), {
+			knownYouTubeSource: true,
+		}),
+	).toBe(YTDLP_STALE_HINT);
 });
 
 test('unrelated errors pass through unchanged', () => {


### PR DESCRIPTION
## Problem

When YouTube rejects a stream (HTTP 403 from googlevideo, common with a stale yt-dlp or on bot-flagged networks), playback just dies with a raw `mpv exited with code 2` and no hint what to do. The app only checked that mpv/yt-dlp exist, never how old yt-dlp is — yet a stale yt-dlp is the most common cause of sudden YouTube 403s.

## Changes

- `source/services/player/ytdl-cookies.ts`: new `isYouTubeLoadFailure` detector (403/Forbidden/failed-to-open/mpv exit 2-3) and `YTDLP_STALE_HINT`; `formatPlaybackErrorMessage` maps these to update-yt-dlp + set-cookies guidance (bot-check mapping takes precedence).
- `source/services/player/dependency-check.service.ts`: startup freshness check — warns when `yt-dlp --version` is over 45 days old. Non-fatal, best-effort.
- `tests/stream-error-hint.test.js`: regression tests for the mappings and version parsing/staleness.

## Verification

- `bun test`: 224 pass, 0 fail
- `bun run typecheck`, eslint, prettier: clean
- Manually confirmed end-to-end: reproduced the 403 with mpv + yt-dlp 2026.07.04, upgraded to 2026.08.19, stream plays.

## Summary by Sourcery

Guide users toward updating yt-dlp or configuring browser cookies when YouTube streams fail to load.

New Features:
- Provide actionable guidance when YouTube playback fails due to rejected streams, including yt-dlp updates and cookie configuration.

Bug Fixes:
- Replace unhelpful raw mpv playback errors with contextual YouTube remediation while preserving bot-check guidance precedence.

Enhancements:
- Warn at startup when the installed yt-dlp version is more than 45 days old without blocking playback.

Tests:
- Add regression coverage for YouTube failure classification, error-message precedence, and yt-dlp version parsing and staleness detection.